### PR TITLE
Use public properties instead of internal for BaseEntryDao as they are not stored.

### DIFF
--- a/src/Catalyst.Core.Lib/DAO/BaseEntryDao.cs
+++ b/src/Catalyst.Core.Lib/DAO/BaseEntryDao.cs
@@ -33,9 +33,9 @@ namespace Catalyst.Core.Lib.DAO
     public class BaseEntryDao : DaoBase
     {
         public ulong Nonce { get; set; }
-        internal string ReceiverPublicKey { get; set; }
+        public string ReceiverPublicKey { get; set; }
         public string SenderPublicKey { get; set; }
-        internal string TransactionFees { get; set; }
+        public string TransactionFees { get; set; }
 
         [Column]
         


### PR DESCRIPTION
Not all properties in the BaseEntryDao are stored in Cosmos Db because the access modifier is set to internal when it should be public.

### New Pull Request Submissions:

1. [x] Have you followed the guidelines in our [Contributing document](https://github.com/atlascity/Community/tree/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
3. [x] I have added tests to cover my changes.
4. [x] All new and existing tests passed.
5. [x] Have you lint your code locally prior to submission?
6. [x] Does your code follows the code style of this project?
7. [x] Does your change require a change to the documentation.
    - [ ] I have updated the documentation accordingly.
9. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
10. [x] Have you inserted a keyword and link to the issues the PR closes in its descriptions (ex `closes #1`) ?
11. [x] Is you branch up to date, have you integrated all the latest changes from develop and resolved conflicts ?

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix
* **What is the current behavior?** (You can also link to an open issue here)
ReceiverPublicKey not stored in cosmos db
* **What is the new behavior (if this is a feature change)?**
ReceiverPublicKey is now stored in cosmos db
* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
* **Other information**:
