### PR TITLE
consensus and crypto perf optimizations

### DIFF
--- a/src/Catalyst.Abstractions/Cryptography/CryptoExtensions.cs
+++ b/src/Catalyst.Abstractions/Cryptography/CryptoExtensions.cs
@@ -1,0 +1,97 @@
+#region LICENSE
+
+/**
+* Copyright (c) 2019 Catalyst Network
+*
+* This file is part of Catalyst.Node <https://github.com/catalyst-network/Catalyst.Node>
+*
+* Catalyst.Node is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 2 of the License, or
+* (at your option) any later version.
+*
+* Catalyst.Node is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Catalyst.Node. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#endregion
+
+using System.Buffers;
+using Google.Protobuf;
+
+namespace Catalyst.Abstractions.Cryptography
+{
+    public static class CryptoExtensions
+    {
+        /// <summary>
+        ///     Signs message using provided private key and returns the signature.
+        /// </summary>
+        /// <param name="crypto"></param>
+        /// <param name="privateKey"></param>
+        /// <param name="message"></param>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public static ISignature Sign(this ICryptoContext crypto, IPrivateKey privateKey, IMessage message, IMessage context)
+        {
+            ProtoPreconditions.CheckNotNull(message, nameof(message));
+            ProtoPreconditions.CheckNotNull(context, nameof(context));
+
+            var messageSize = message.CalculateSize();
+            var messageArray = ArrayPool<byte>.Shared.Rent(messageSize);
+            
+            var contextSize = context.CalculateSize();
+            var contextArray = ArrayPool<byte>.Shared.Rent(contextSize);
+
+            using (var output = new CodedOutputStream(messageArray))
+            {
+                message.WriteTo(output);
+            } 
+            
+            using (var output = new CodedOutputStream(contextArray))
+            {
+                context.WriteTo(output);
+            }
+
+            var signature = crypto.Sign(privateKey, messageArray, messageSize, contextArray, contextSize);
+
+            ArrayPool<byte>.Shared.Return(messageArray);
+            ArrayPool<byte>.Shared.Return(contextArray);
+
+            return signature;
+        }
+
+        public static bool Verify(this ICryptoContext crypto, ISignature signature, IMessage message, IMessage context)
+        {
+            ProtoPreconditions.CheckNotNull(message, nameof(message));
+            ProtoPreconditions.CheckNotNull(context, nameof(context));
+
+            var messageSize = message.CalculateSize();
+            var messageArray = ArrayPool<byte>.Shared.Rent(messageSize);
+
+            var contextSize = context.CalculateSize();
+            var contextArray = ArrayPool<byte>.Shared.Rent(contextSize);
+
+            using (var output = new CodedOutputStream(messageArray))
+            {
+                message.WriteTo(output);
+            }
+
+            using (var output = new CodedOutputStream(contextArray))
+            {
+                context.WriteTo(output);
+            }
+
+            var result = crypto.Verify(signature, messageArray, messageSize, contextArray, contextSize);
+
+            ArrayPool<byte>.Shared.Return(messageArray);
+            ArrayPool<byte>.Shared.Return(contextArray);
+
+            return result;
+        }
+    }
+}

--- a/src/Catalyst.Abstractions/Cryptography/ICryptoContext.cs
+++ b/src/Catalyst.Abstractions/Cryptography/ICryptoContext.cs
@@ -103,6 +103,19 @@ namespace Catalyst.Abstractions.Cryptography
         /// <returns></returns>
         ISignature Sign(IPrivateKey privateKey, byte[] message, byte[] context);
 
+        /// <summary>
+        ///     Signs message using provided private key and returns the signature.
+        /// </summary>
+        /// <param name="privateKey"></param>
+        /// <param name="message"></param>
+        /// <param name="messageLength"></param>
+        /// <param name="context"></param>
+        /// <param name="contextLength"></param>
+        /// <returns></returns>
+        ISignature Sign(IPrivateKey privateKey, byte[] message, int messageLength, byte[] context, int contextLength);
+
         bool Verify(ISignature signature, byte[] message, byte[] context);
+        
+        bool Verify(ISignature signature, byte[] message, int messageLength, byte[] context, int contextLength);
     }
 }

--- a/src/Catalyst.Abstractions/Cryptography/ICryptoContext.cs
+++ b/src/Catalyst.Abstractions/Cryptography/ICryptoContext.cs
@@ -21,6 +21,8 @@
 
 #endregion
 
+using System;
+
 namespace Catalyst.Abstractions.Cryptography
 {
     public interface ICryptoContext
@@ -101,21 +103,8 @@ namespace Catalyst.Abstractions.Cryptography
         /// <param name="message"></param>
         /// <param name="context"></param>
         /// <returns></returns>
-        ISignature Sign(IPrivateKey privateKey, byte[] message, byte[] context);
+        ISignature Sign(IPrivateKey privateKey, ReadOnlySpan<byte> message, ReadOnlySpan<byte> context);
 
-        /// <summary>
-        ///     Signs message using provided private key and returns the signature.
-        /// </summary>
-        /// <param name="privateKey"></param>
-        /// <param name="message"></param>
-        /// <param name="messageLength"></param>
-        /// <param name="context"></param>
-        /// <param name="contextLength"></param>
-        /// <returns></returns>
-        ISignature Sign(IPrivateKey privateKey, byte[] message, int messageLength, byte[] context, int contextLength);
-
-        bool Verify(ISignature signature, byte[] message, byte[] context);
-        
-        bool Verify(ISignature signature, byte[] message, int messageLength, byte[] context, int contextLength);
+        bool Verify(ISignature signature, ReadOnlySpan<byte> message, ReadOnlySpan<byte> context);
     }
 }

--- a/src/Catalyst.Abstractions/Hashing/HashExtensions.cs
+++ b/src/Catalyst.Abstractions/Hashing/HashExtensions.cs
@@ -1,0 +1,86 @@
+#region LICENSE
+
+/**
+* Copyright (c) 2019 Catalyst Network
+*
+* This file is part of Catalyst.Node <https://github.com/catalyst-network/Catalyst.Node>
+*
+* Catalyst.Node is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 2 of the License, or
+* (at your option) any later version.
+*
+* Catalyst.Node is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Catalyst.Node. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#endregion
+
+using System.Buffers;
+using Google.Protobuf;
+using TheDotNetLeague.MultiFormats.MultiHash;
+
+namespace Catalyst.Abstractions.Hashing
+{
+    public static class HashExtensions
+    {
+        /// <summary>
+        /// Serializes the <paramref name="message"/>, appends suffix and returns the hash of it.
+        /// </summary>
+        /// <param name="provider">The hash provider.</param>
+        /// <param name="message">The protocol message.</param>
+        /// <param name="suffix">The suffix that should be appended to the message. </param>
+        /// <returns></returns>
+        public static MultiHash ComputeMultiHash(this IHashProvider provider, IMessage message, byte[] suffix)
+        {
+            ProtoPreconditions.CheckNotNull(message, nameof(message));
+            var calculateSize = message.CalculateSize();
+
+            var required = calculateSize + suffix.Length;
+            var array = ArrayPool<byte>.Shared.Rent(required);
+
+            using (var output = new CodedOutputStream(array)) 
+            {
+                message.WriteTo(output);
+            }
+
+            suffix.CopyTo(array, calculateSize);
+
+            var result = provider.ComputeMultiHash(array, 0, required);
+            
+            ArrayPool<byte>.Shared.Return(array);
+            
+            return result;
+        }
+
+        /// <summary>
+        /// Serializes the <paramref name="message"/> returns the hash of it.
+        /// </summary>
+        /// <param name="provider">The hash provider.</param>
+        /// <param name="message">The protocol message.</param>
+        /// <returns></returns>
+        public static MultiHash ComputeMultiHash(this IHashProvider provider, IMessage message)
+        {
+            ProtoPreconditions.CheckNotNull(message, nameof(message));
+            var required = message.CalculateSize();
+
+            var array = ArrayPool<byte>.Shared.Rent(required);
+
+            using (var output = new CodedOutputStream(array))
+            {
+                message.WriteTo(output);
+            }
+
+            var result = provider.ComputeMultiHash(array, 0, required);
+
+            ArrayPool<byte>.Shared.Return(array);
+
+            return result;
+        }
+    }
+}

--- a/src/Catalyst.Abstractions/Hashing/IHashProvider.cs
+++ b/src/Catalyst.Abstractions/Hashing/IHashProvider.cs
@@ -37,5 +37,6 @@ namespace Catalyst.Abstractions.Hashing
         MultiHash ComputeMultiHash(IEnumerable<byte> content);
         MultiHash Cast(byte[] data);
         bool IsValidHash(byte[] data);
+        MultiHash ComputeMultiHash(byte[] data, int offset, int count);
     }
 }

--- a/src/Catalyst.Abstractions/KeySigner/IKeySigner.cs
+++ b/src/Catalyst.Abstractions/KeySigner/IKeySigner.cs
@@ -24,6 +24,7 @@
 using Catalyst.Abstractions.Cryptography;
 using Catalyst.Abstractions.Keystore;
 using Catalyst.Protocol.Cryptography;
+using Google.Protobuf;
 using ISignature = Catalyst.Abstractions.Cryptography.ISignature;
 
 namespace Catalyst.Abstractions.KeySigner
@@ -42,8 +43,14 @@ namespace Catalyst.Abstractions.KeySigner
         
         ISignature Sign(byte[] data, SigningContext signingContext);
 
+        ISignature Sign(IMessage data, SigningContext signingContext);
+
         /// <summary>Verifies a message signature.</summary>
         /// <returns></returns>
         bool Verify(ISignature signature, byte[] message, SigningContext signingContext);
+
+        /// <summary>Verifies a message signature.</summary>
+        /// <returns></returns>
+        bool Verify(ISignature signature, IMessage message, SigningContext signingContext);
     }
 }

--- a/src/Catalyst.Abstractions/KeySigner/IKeySigner.cs
+++ b/src/Catalyst.Abstractions/KeySigner/IKeySigner.cs
@@ -21,10 +21,10 @@
 
 #endregion
 
+using System;
 using Catalyst.Abstractions.Cryptography;
 using Catalyst.Abstractions.Keystore;
 using Catalyst.Protocol.Cryptography;
-using Google.Protobuf;
 using ISignature = Catalyst.Abstractions.Cryptography.ISignature;
 
 namespace Catalyst.Abstractions.KeySigner
@@ -40,17 +40,11 @@ namespace Catalyst.Abstractions.KeySigner
         ///     Takes the crypto library implementation the nodes using.
         /// </summary>
         ICryptoContext CryptoContext { get; }
-        
-        ISignature Sign(byte[] data, SigningContext signingContext);
 
-        ISignature Sign(IMessage data, SigningContext signingContext);
+        ISignature Sign(ReadOnlySpan<byte> data, SigningContext signingContext);
 
         /// <summary>Verifies a message signature.</summary>
         /// <returns></returns>
-        bool Verify(ISignature signature, byte[] message, SigningContext signingContext);
-
-        /// <summary>Verifies a message signature.</summary>
-        /// <returns></returns>
-        bool Verify(ISignature signature, IMessage message, SigningContext signingContext);
+        bool Verify(ISignature signature, ReadOnlySpan<byte> data, SigningContext signingContext);
     }
 }

--- a/src/Catalyst.Abstractions/KeySigner/KeySignerExtensions.cs
+++ b/src/Catalyst.Abstractions/KeySigner/KeySignerExtensions.cs
@@ -1,0 +1,68 @@
+#region LICENSE
+
+/**
+* Copyright (c) 2019 Catalyst Network
+*
+* This file is part of Catalyst.Node <https://github.com/catalyst-network/Catalyst.Node>
+*
+* Catalyst.Node is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 2 of the License, or
+* (at your option) any later version.
+*
+* Catalyst.Node is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Catalyst.Node. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#endregion
+
+using System;
+using System.Buffers;
+using Catalyst.Abstractions.Cryptography;
+using Catalyst.Protocol.Cryptography;
+using Google.Protobuf;
+
+namespace Catalyst.Abstractions.KeySigner
+{
+    public static class KeySignerExtensions
+    {
+        public static ISignature Sign(this IKeySigner crypto, IMessage message, SigningContext context)
+        {
+            var messageSize = message.CalculateSize();
+            var array = ArrayPool<byte>.Shared.Rent(messageSize);
+
+            using (var output = new CodedOutputStream(array))
+            {
+                message.WriteTo(output);
+            }
+
+            var result = crypto.Sign(array.AsSpan(0, messageSize), context);
+
+            ArrayPool<byte>.Shared.Return(array);
+
+            return result;
+        }
+
+        public static bool Verify(this IKeySigner crypto, ISignature signature, IMessage message, SigningContext context)
+        {
+            var messageSize = message.CalculateSize();
+            var array = ArrayPool<byte>.Shared.Rent(messageSize);
+
+            using (var output = new CodedOutputStream(array))
+            {
+                message.WriteTo(output);
+            }
+
+            var result = crypto.Verify(signature, array.AsSpan(0, messageSize), context);
+
+            ArrayPool<byte>.Shared.Return(array);
+
+            return result;
+        }
+    }
+}

--- a/src/Catalyst.Benchmark/Catalyst.Abstractions/CryptoBenchmark.cs
+++ b/src/Catalyst.Benchmark/Catalyst.Abstractions/CryptoBenchmark.cs
@@ -92,10 +92,8 @@ namespace Catalyst.Benchmark.Catalyst.Core.Modules.Hashing
 
         internal class NoopCryptoContext : ICryptoContext
         {
-            public ISignature Sign(IPrivateKey privateKey, byte[] message, byte[] context) => null;
-            public ISignature Sign(IPrivateKey privateKey, byte[] message, int messageLength, byte[] context, int contextLength) => null;
-            public bool Verify(ISignature signature, byte[] message, byte[] context) => true;
-            public bool Verify(ISignature signature, byte[] message, int messageLength, byte[] context, int contextLength) => true;
+            public ISignature Sign(IPrivateKey privateKey, ReadOnlySpan<byte> message, ReadOnlySpan<byte> context) => null;
+            public bool Verify(ISignature signature, ReadOnlySpan<byte> message, ReadOnlySpan<byte> context) => true;
 
             public int PrivateKeyLength => throw new NotImplementedException();
             public int PublicKeyLength => throw new NotImplementedException();

--- a/src/Catalyst.Benchmark/Catalyst.Abstractions/CryptoBenchmark.cs
+++ b/src/Catalyst.Benchmark/Catalyst.Abstractions/CryptoBenchmark.cs
@@ -1,0 +1,90 @@
+using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Catalyst.Abstractions.Cryptography;
+using Catalyst.Protocol.Cryptography;
+using Catalyst.Protocol.Network;
+using Catalyst.Protocol.Transaction;
+using Catalyst.Protocol.Wire;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Catalyst.Benchmark.Catalyst.Core.Modules.Hashing
+{
+    [MemoryDiagnoser]
+    [SimpleJob(RuntimeMoniker.CoreRt30)]
+    public class CryptoBenchmark
+    {
+        static CryptoBenchmark()
+        {
+            Context = new SigningContext
+            {
+                NetworkType = NetworkType.Mainnet,
+                SignatureType = SignatureType.TransactionConfidential
+            };
+
+            var key = ByteString.CopyFrom(new byte[32]);
+            var amount = ByteString.CopyFrom(new byte[32]);
+
+            Transaction = new TransactionBroadcast
+            {
+                PublicEntries =
+                {
+                    new PublicEntry
+                    {
+                        Amount = amount,
+                        Base = new BaseEntry
+                        {
+                            Nonce = 1,
+                            SenderPublicKey = key,
+                            ReceiverPublicKey = key,
+                            TransactionFees = amount
+                        }
+                    }
+                },
+                Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            };
+
+            Crypto = new NoopCryptoContext();
+        }
+
+        static readonly SigningContext Context;
+        static readonly TransactionBroadcast Transaction;
+        static readonly ICryptoContext Crypto;
+        static readonly IPrivateKey PrivateKey = null;
+
+        [Benchmark]
+        public bool SignVerify_with_ToByteArray()
+        {
+            var signature = Crypto.Sign(PrivateKey, Transaction.ToByteArray(), Context.ToByteArray());
+            return Crypto.Verify(signature, Transaction.ToByteArray(), Context.ToByteArray());
+        }
+        
+        [Benchmark]
+        public bool SignVerify_with_embedded_serialization()
+        {
+            var signature = Crypto.Sign(PrivateKey, Transaction, Context);
+            return Crypto.Verify(signature, Transaction, Context);
+        }
+
+        internal class NoopCryptoContext : ICryptoContext
+        {
+            public ISignature Sign(IPrivateKey privateKey, byte[] message, byte[] context) => null;
+            public ISignature Sign(IPrivateKey privateKey, byte[] message, int messageLength, byte[] context, int contextLength) => null;
+            public bool Verify(ISignature signature, byte[] message, byte[] context) => true;
+            public bool Verify(ISignature signature, byte[] message, int messageLength, byte[] context, int contextLength) => true;
+
+            public int PrivateKeyLength => throw new NotImplementedException();
+            public int PublicKeyLength => throw new NotImplementedException();
+            public int SignatureLength => throw new NotImplementedException();
+            public int SignatureContextMaxLength => throw new NotImplementedException();
+            public IPrivateKey GeneratePrivateKey() { throw new NotImplementedException(); }
+            public IPublicKey GetPublicKeyFromPrivateKey(IPrivateKey privateKey) { throw new NotImplementedException(); }
+            public IPublicKey GetPublicKeyFromBytes(byte[] publicKeyBytes) { throw new NotImplementedException(); }
+            public IPrivateKey GetPrivateKeyFromBytes(byte[] privateKeyBytes) { throw new NotImplementedException(); }
+            public ISignature GetSignatureFromBytes(byte[] signatureBytes, byte[] publicKeyBytes) { throw new NotImplementedException(); }
+            public byte[] ExportPrivateKey(IPrivateKey privateKey) { throw new NotImplementedException(); }
+            public byte[] ExportPublicKey(IPublicKey publicKey) { throw new NotImplementedException(); }
+        }
+    }
+}

--- a/src/Catalyst.Benchmark/Catalyst.Abstractions/CryptoBenchmark.cs
+++ b/src/Catalyst.Benchmark/Catalyst.Abstractions/CryptoBenchmark.cs
@@ -38,9 +38,9 @@ namespace Catalyst.Benchmark.Catalyst.Core.Modules.Hashing
     [SimpleJob(RuntimeMoniker.CoreRt30)]
     public class CryptoBenchmark
     {
-        static CryptoBenchmark()
+        public CryptoBenchmark()
         {
-            Context = new SigningContext
+            _context = new SigningContext
             {
                 NetworkType = NetworkType.Mainnet,
                 SignatureType = SignatureType.TransactionConfidential
@@ -49,7 +49,7 @@ namespace Catalyst.Benchmark.Catalyst.Core.Modules.Hashing
             var key = ByteString.CopyFrom(new byte[32]);
             var amount = ByteString.CopyFrom(new byte[32]);
 
-            Transaction = new TransactionBroadcast
+            _transaction = new TransactionBroadcast
             {
                 PublicEntries =
                 {
@@ -68,26 +68,25 @@ namespace Catalyst.Benchmark.Catalyst.Core.Modules.Hashing
                 Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
             };
 
-            Crypto = new NoopCryptoContext();
+            _crypto = new NoopCryptoContext();
         }
 
-        static readonly SigningContext Context;
-        static readonly TransactionBroadcast Transaction;
-        static readonly ICryptoContext Crypto;
-        static readonly IPrivateKey PrivateKey = null;
+        readonly SigningContext _context;
+        readonly TransactionBroadcast _transaction;
+        readonly ICryptoContext _crypto;
 
         [Benchmark]
         public bool SignVerify_with_ToByteArray()
         {
-            var signature = Crypto.Sign(PrivateKey, Transaction.ToByteArray(), Context.ToByteArray());
-            return Crypto.Verify(signature, Transaction.ToByteArray(), Context.ToByteArray());
+            var signature = _crypto.Sign(null, _transaction.ToByteArray(), _context.ToByteArray());
+            return _crypto.Verify(signature, _transaction.ToByteArray(), _context.ToByteArray());
         }
         
         [Benchmark]
         public bool SignVerify_with_embedded_serialization()
         {
-            var signature = Crypto.Sign(PrivateKey, Transaction, Context);
-            return Crypto.Verify(signature, Transaction, Context);
+            var signature = _crypto.Sign(null, _transaction, _context);
+            return _crypto.Verify(signature, _transaction, _context);
         }
 
         internal class NoopCryptoContext : ICryptoContext

--- a/src/Catalyst.Benchmark/Catalyst.Abstractions/CryptoBenchmark.cs
+++ b/src/Catalyst.Benchmark/Catalyst.Abstractions/CryptoBenchmark.cs
@@ -1,3 +1,26 @@
+#region LICENSE
+
+/**
+* Copyright (c) 2019 Catalyst Network
+*
+* This file is part of Catalyst.Node <https://github.com/catalyst-network/Catalyst.Node>
+*
+* Catalyst.Node is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 2 of the License, or
+* (at your option) any later version.
+*
+* Catalyst.Node is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Catalyst.Node. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#endregion
+
 using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;

--- a/src/Catalyst.Benchmark/Catalyst.Abstractions/HashingBenchmark.cs
+++ b/src/Catalyst.Benchmark/Catalyst.Abstractions/HashingBenchmark.cs
@@ -95,7 +95,10 @@ namespace Catalyst.Benchmark.Catalyst.Core.Modules.Hashing
                 return true;
             }
 
-            protected override void HashCore(ReadOnlySpan<byte> source) { }
+            protected override void HashCore(ReadOnlySpan<byte> source)
+            {
+                // this is a noop hasher that is used only for benchmarking purposes, to shaw the overhead of non-hashing operations
+            }
         }
     }
 }

--- a/src/Catalyst.Benchmark/Catalyst.Abstractions/HashingBenchmark.cs
+++ b/src/Catalyst.Benchmark/Catalyst.Abstractions/HashingBenchmark.cs
@@ -1,3 +1,26 @@
+#region LICENSE
+
+/**
+* Copyright (c) 2019 Catalyst Network
+*
+* This file is part of Catalyst.Node <https://github.com/catalyst-network/Catalyst.Node>
+*
+* Catalyst.Node is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 2 of the License, or
+* (at your option) any later version.
+*
+* Catalyst.Node is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Catalyst.Node. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#endregion
+
 using System;
 using System.Linq;
 using System.Security.Cryptography;

--- a/src/Catalyst.Benchmark/Catalyst.Abstractions/HashingBenchmark.cs
+++ b/src/Catalyst.Benchmark/Catalyst.Abstractions/HashingBenchmark.cs
@@ -39,7 +39,7 @@ namespace Catalyst.Benchmark.Catalyst.Core.Modules.Hashing
     [SimpleJob(RuntimeMoniker.CoreRt30)]
     public class HashingBenchmark
     {
-        static HashingBenchmark()
+        public HashingBenchmark()
         {
             const string name = nameof(NoopHash);
 
@@ -48,7 +48,7 @@ namespace Catalyst.Benchmark.Catalyst.Core.Modules.Hashing
             var bytes = ByteString.CopyFrom(Enumerable.Range(1, 32).Select(i => (byte)i).ToArray());
             var amount = ByteString.CopyFrom(343434.ToByteArray(Bytes.Endianness.Big));
 
-            Entry = new PublicEntry
+            _entry = new PublicEntry
             {
                 Amount = amount,
                 Base = new BaseEntry
@@ -59,23 +59,23 @@ namespace Catalyst.Benchmark.Catalyst.Core.Modules.Hashing
                 }
             };
 
-            Provider = new HashProvider(HashingAlgorithm.GetAlgorithmMetadata(name));
+            _provider = new HashProvider(HashingAlgorithm.GetAlgorithmMetadata(name));
         }
 
-        static readonly HashProvider Provider;
-        static readonly PublicEntry Entry;
-        static readonly byte[] Salt = {1, 2, 3, 4};
+        readonly HashProvider _provider;
+        readonly PublicEntry _entry;
+        readonly byte[] _salt = {1, 2, 3, 4};
 
         [Benchmark]
         public MultiHash Concat_manual()
         {
-            return Provider.ComputeMultiHash(Entry.ToByteArray().Concat(Salt));
+            return _provider.ComputeMultiHash(_entry.ToByteArray().Concat(_salt));
         }
 
         [Benchmark]
         public MultiHash Concat_embedded()
         {
-            return Provider.ComputeMultiHash(Entry, Salt);
+            return _provider.ComputeMultiHash(_entry, _salt);
         }
 
         internal class NoopHash : HashAlgorithm

--- a/src/Catalyst.Benchmark/Catalyst.Abstractions/HashingBenchmark.cs
+++ b/src/Catalyst.Benchmark/Catalyst.Abstractions/HashingBenchmark.cs
@@ -14,9 +14,9 @@ namespace Catalyst.Benchmark.Catalyst.Core.Modules.Hashing
 {
     [MemoryDiagnoser]
     [SimpleJob(RuntimeMoniker.CoreRt30)]
-    public class HashProviderBenchmark
+    public class HashingBenchmark
     {
-        static HashProviderBenchmark()
+        static HashingBenchmark()
         {
             const string name = nameof(NoopHash);
 

--- a/src/Catalyst.Benchmark/Catalyst.Benchmark.csproj
+++ b/src/Catalyst.Benchmark/Catalyst.Benchmark.csproj
@@ -5,6 +5,11 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Catalyst.Benchmark/Catalyst.Benchmark.csproj
+++ b/src/Catalyst.Benchmark/Catalyst.Benchmark.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="BenchmarkDotNet.Artifacts\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Catalyst.Core.Modules.Hashing\Catalyst.Core.Modules.Hashing.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Catalyst.Benchmark/Catalyst.Core.Modules.Hashing/HashProviderBenchmark.cs
+++ b/src/Catalyst.Benchmark/Catalyst.Core.Modules.Hashing/HashProviderBenchmark.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Catalyst.Abstractions.Hashing;
+using Catalyst.Core.Modules.Hashing;
+using Catalyst.Protocol.Transaction;
+using Google.Protobuf;
+using Nethermind.Core.Extensions;
+using TheDotNetLeague.MultiFormats.MultiHash;
+
+namespace Catalyst.Benchmark.Catalyst.Core.Modules.Hashing
+{
+    [MemoryDiagnoser]
+    [SimpleJob(RuntimeMoniker.CoreRt30)]
+    public class HashProviderBenchmark
+    {
+        static HashProviderBenchmark()
+        {
+            const string name = nameof(NoopHash);
+
+            HashingAlgorithm.Register(name, 1234123421, NoopHash.DigestSize, () => new NoopHash());
+
+            var bytes = ByteString.CopyFrom(Enumerable.Range(1, 32).Select(i => (byte)i).ToArray());
+            var amount = ByteString.CopyFrom(343434.ToByteArray(Bytes.Endianness.Big));
+
+            Entry = new PublicEntry
+            {
+                Amount = amount,
+                Base = new BaseEntry
+                {
+                    TransactionFees = amount,
+                    ReceiverPublicKey = bytes,
+                    SenderPublicKey = bytes,
+                }
+            };
+
+            Provider = new HashProvider(HashingAlgorithm.GetAlgorithmMetadata(name));
+        }
+
+        static readonly HashProvider Provider;
+        static readonly PublicEntry Entry;
+        static readonly byte[] Salt = {1, 2, 3, 4};
+
+        [Benchmark]
+        public MultiHash Concat_manual()
+        {
+            return Provider.ComputeMultiHash(Entry.ToByteArray().Concat(Salt));
+        }
+
+        [Benchmark]
+        public MultiHash Concat_embedded()
+        {
+            return Provider.ComputeMultiHash(Entry, Salt);
+        }
+
+        internal class NoopHash : HashAlgorithm
+        {
+            public const int DigestSize = 32;
+            static readonly byte[] Value = new byte[DigestSize];
+
+            protected override void HashCore(byte[] array, int ibStart, int cbSize) { }
+
+            protected override byte[] HashFinal() => Value;
+
+            public override void Initialize() { }
+
+            protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten)
+            {
+                bytesWritten = destination.Length;
+                return true;
+            }
+
+            protected override void HashCore(ReadOnlySpan<byte> source) { }
+        }
+    }
+}

--- a/src/Catalyst.Benchmark/Program.cs
+++ b/src/Catalyst.Benchmark/Program.cs
@@ -1,0 +1,13 @@
+using System;
+using BenchmarkDotNet.Running;
+
+namespace Catalyst.Benchmark
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            BenchmarkRunner.Run(typeof(Program).Assembly);
+        }
+    }
+}

--- a/src/Catalyst.Benchmark/Program.cs
+++ b/src/Catalyst.Benchmark/Program.cs
@@ -1,3 +1,26 @@
+#region LICENSE
+
+/**
+* Copyright (c) 2019 Catalyst Network
+*
+* This file is part of Catalyst.Node <https://github.com/catalyst-network/Catalyst.Node>
+*
+* Catalyst.Node is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 2 of the License, or
+* (at your option) any later version.
+*
+* Catalyst.Node is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Catalyst.Node. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#endregion
+
 using System;
 using BenchmarkDotNet.Running;
 

--- a/src/Catalyst.Benchmark/Program.cs
+++ b/src/Catalyst.Benchmark/Program.cs
@@ -26,7 +26,7 @@ using BenchmarkDotNet.Running;
 
 namespace Catalyst.Benchmark
 {
-    public class Program
+    public static class Program
     {
         public static void Main(string[] args)
         {

--- a/src/Catalyst.Core.Lib.Tests/Fakes/FakeKeySigner.cs
+++ b/src/Catalyst.Core.Lib.Tests/Fakes/FakeKeySigner.cs
@@ -63,13 +63,13 @@ namespace Catalyst.Core.Lib.Tests.Fakes
 
         public ISignature Sign(ReadOnlySpan<byte> data, SigningContext signingContext)
         {
-            if (_allowSign == false)
+            if (_allowSign)
             {
-                throw new NotImplementedException();
+                SignCount++;
+                return Signature;
             }
 
-            SignCount++;
-            return Signature;
+            throw new NotImplementedException();
         }
 
         public bool Verify(ISignature signature, ReadOnlySpan<byte> data, SigningContext signingContext)

--- a/src/Catalyst.Core.Lib.Tests/Fakes/FakeKeySigner.cs
+++ b/src/Catalyst.Core.Lib.Tests/Fakes/FakeKeySigner.cs
@@ -1,0 +1,88 @@
+#region LICENSE
+
+/**
+* Copyright (c) 2019 Catalyst Network
+*
+* This file is part of Catalyst.Node <https://github.com/catalyst-network/Catalyst.Node>
+*
+* Catalyst.Node is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 2 of the License, or
+* (at your option) any later version.
+*
+* Catalyst.Node is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Catalyst.Node. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#endregion
+
+using System;
+using Catalyst.Abstractions.Cryptography;
+using Catalyst.Abstractions.KeySigner;
+using Catalyst.Abstractions.Keystore;
+using Catalyst.Protocol.Cryptography;
+using NSubstitute;
+
+namespace Catalyst.Core.Lib.Tests.Fakes 
+{
+    /// <summary>
+    /// A fake, that emulates <see cref="Substitute.For{T}"/> result.
+    /// Due to usage of <see cref="Span{T}"/> in API which is by-ref struct, that cannot be boxed, it is not supported by <see cref="NSubstitute"/> API.
+    /// </summary>
+    class FakeKeySigner : IKeySigner
+    {
+        bool? _verifyResult;
+        readonly bool _allowSign;
+
+        public int SignCount { get; private set; }
+        public int VerifyCount { get; private set; }
+
+        public ISignature Signature { get; }
+
+        public static FakeKeySigner SignOnly() => new FakeKeySigner(null, true);
+
+        public static FakeKeySigner VerifyOnly(bool verifyResult = true) => new FakeKeySigner(verifyResult, false);
+
+        public static FakeKeySigner SignAndVerify(bool verifyResult = true) => new FakeKeySigner(verifyResult, true);
+
+        FakeKeySigner(bool? verifyResult, bool allowSign)
+        {
+            _verifyResult = verifyResult;
+            _allowSign = allowSign;
+            CryptoContext = Substitute.For<ICryptoContext>();
+            Signature = Substitute.For<ISignature>();
+        }
+
+        public IKeyStore KeyStore => throw new NotImplementedException();
+        public ICryptoContext CryptoContext { get; set; }
+
+        public ISignature Sign(ReadOnlySpan<byte> data, SigningContext signingContext)
+        {
+            if (_allowSign == false)
+            {
+                throw new NotImplementedException();
+            }
+
+            SignCount++;
+            return Signature;
+        }
+
+        public bool Verify(ISignature signature, ReadOnlySpan<byte> data, SigningContext signingContext)
+        {
+            if (_verifyResult == null)
+            {
+                throw new NotImplementedException();
+            }
+
+            VerifyCount++;
+            return _verifyResult.Value;
+        }
+
+        public void EnableVerification(bool isValid) { _verifyResult = isValid; }
+    }
+}

--- a/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/IO/Transport/Channels/PeerClientChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/IO/Transport/Channels/PeerClientChannelFactoryTests.cs
@@ -32,6 +32,7 @@ using Catalyst.Core.Lib.Extensions;
 using Catalyst.Core.Lib.IO.Handlers;
 using Catalyst.Core.Lib.IO.Messaging.Correlation;
 using Catalyst.Core.Lib.IO.Messaging.Dto;
+using Catalyst.Core.Lib.Tests.Fakes;
 using Catalyst.Protocol.Wire;
 using Catalyst.Protocol.IPPN;
 using Catalyst.Protocol.Network;
@@ -55,17 +56,16 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
         private readonly EmbeddedChannel _serverChannel;
         private readonly EmbeddedChannel _clientChannel;
         private readonly IPeerMessageCorrelationManager _clientCorrelationManager;
-        private readonly IKeySigner _clientKeySigner;
+        private readonly FakeKeySigner _clientKeySigner;
         private readonly IPeerIdValidator _peerIdValidator;
-        private readonly IKeySigner _serverKeySigner;
+        private readonly FakeKeySigner _serverKeySigner;
         private readonly IPeerMessageCorrelationManager _serverCorrelationManager;
-        private readonly ISignature _signature;
 
         public PeerClientChannelFactoryTests()
         {
             _testScheduler = new TestScheduler();
             _serverCorrelationManager = Substitute.For<IPeerMessageCorrelationManager>();
-            _serverKeySigner = Substitute.For<IKeySigner>();
+            _serverKeySigner = FakeKeySigner.SignOnly();
             _serverKeySigner.CryptoContext.SignatureLength.Returns(64);
             var broadcastManager = Substitute.For<IBroadcastManager>();
 
@@ -82,10 +82,8 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
                 peerSettings,
                 _testScheduler);
 
-            _signature = Substitute.For<ISignature>();
-
             _clientCorrelationManager = Substitute.For<IPeerMessageCorrelationManager>();
-            _clientKeySigner = Substitute.For<IKeySigner>();
+            _clientKeySigner = FakeKeySigner.VerifyOnly();
             _clientKeySigner.CryptoContext.SignatureLength.Returns(64);
 
             _clientFactory = new UnitTests.P2P.IO.Transport.Channels.PeerClientChannelFactoryTests.TestPeerClientChannelFactory(
@@ -111,8 +109,6 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
             var sender = PeerIdHelper.GetPeerId("sender");
             _peerIdValidator.ValidatePeerIdFormat(Arg.Any<PeerId>()).Returns(true);
 
-            _serverKeySigner.Sign(Arg.Any<IMessage>(), default).ReturnsForAnyArgs(_signature);
-            
             var correlationId = CorrelationId.GenerateCorrelationId();
 
             var protocolMessage = new PingRequest().ToProtocolMessage(sender, correlationId);
@@ -125,15 +121,8 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
 
             _serverCorrelationManager.ReceivedWithAnyArgs(1)
                .AddPendingRequest(Arg.Any<CorrelatableMessage<ProtocolMessage>>());
-            
-            _serverKeySigner.ReceivedWithAnyArgs(1).Sign(Arg.Any<IMessage>(), default);
-            
-            _clientKeySigner.Verify(
-                    Arg.Any<ISignature>(),
-                    Arg.Any<IMessage>(), 
-                    default
-                )
-               .ReturnsForAnyArgs(true);
+
+            _serverKeySigner.SignCount.Should().Be(1);
             
             var observer = new ProtocolMessageObserver(0, Substitute.For<ILogger>());
 
@@ -145,7 +134,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
                 _clientChannel.ReadInbound<ProtocolMessage>();
                 _clientCorrelationManager.DidNotReceiveWithAnyArgs().TryMatchResponse(Arg.Any<ProtocolMessage>());
 
-                _clientKeySigner.ReceivedWithAnyArgs(1).Verify(null, default(IMessage), null);
+                _clientKeySigner.VerifyCount.Should().Be(1);
 
                 _testScheduler.Start();
 

--- a/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/IO/Transport/Channels/PeerClientChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/IO/Transport/Channels/PeerClientChannelFactoryTests.cs
@@ -144,7 +144,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
                 _clientChannel.ReadInbound<ProtocolMessage>();
                 _clientCorrelationManager.DidNotReceiveWithAnyArgs().TryMatchResponse(Arg.Any<ProtocolMessage>());
 
-                _clientKeySigner.ReceivedWithAnyArgs(1).Verify(null, null, null);
+                _clientKeySigner.ReceivedWithAnyArgs(1).Verify(null, default(byte[]), null);
 
                 _testScheduler.Start();
 

--- a/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/IO/Transport/Channels/PeerClientChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/IO/Transport/Channels/PeerClientChannelFactoryTests.cs
@@ -40,6 +40,7 @@ using Catalyst.TestUtils;
 using DotNetty.Transport.Channels.Embedded;
 using DotNetty.Transport.Channels.Sockets;
 using FluentAssertions;
+using Google.Protobuf;
 using Microsoft.Reactive.Testing;
 using NSubstitute;
 using Serilog;
@@ -110,7 +111,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
             var sender = PeerIdHelper.GetPeerId("sender");
             _peerIdValidator.ValidatePeerIdFormat(Arg.Any<PeerId>()).Returns(true);
 
-            _serverKeySigner.Sign(Arg.Any<byte[]>(), default).ReturnsForAnyArgs(_signature);
+            _serverKeySigner.Sign(Arg.Any<IMessage>(), default).ReturnsForAnyArgs(_signature);
             
             var correlationId = CorrelationId.GenerateCorrelationId();
 
@@ -125,11 +126,11 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
             _serverCorrelationManager.ReceivedWithAnyArgs(1)
                .AddPendingRequest(Arg.Any<CorrelatableMessage<ProtocolMessage>>());
             
-            _serverKeySigner.ReceivedWithAnyArgs(1).Sign(Arg.Any<byte[]>(), default);
+            _serverKeySigner.ReceivedWithAnyArgs(1).Sign(Arg.Any<IMessage>(), default);
             
             _clientKeySigner.Verify(
                     Arg.Any<ISignature>(),
-                    Arg.Any<byte[]>(), 
+                    Arg.Any<IMessage>(), 
                     default
                 )
                .ReturnsForAnyArgs(true);
@@ -144,7 +145,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
                 _clientChannel.ReadInbound<ProtocolMessage>();
                 _clientCorrelationManager.DidNotReceiveWithAnyArgs().TryMatchResponse(Arg.Any<ProtocolMessage>());
 
-                _clientKeySigner.ReceivedWithAnyArgs(1).Verify(null, default(byte[]), null);
+                _clientKeySigner.ReceivedWithAnyArgs(1).Verify(null, default(IMessage), null);
 
                 _testScheduler.Start();
 

--- a/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/IO/Transport/Channels/PeerServerChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/IO/Transport/Channels/PeerServerChannelFactoryTests.cs
@@ -23,8 +23,6 @@
 
 using System.Linq;
 using System.Threading.Tasks;
-using Catalyst.Abstractions.Cryptography;
-using Catalyst.Abstractions.KeySigner;
 using Catalyst.Abstractions.P2P;
 using Catalyst.Abstractions.P2P.IO.Messaging.Broadcast;
 using Catalyst.Abstractions.P2P.IO.Messaging.Correlation;
@@ -32,6 +30,7 @@ using Catalyst.Core.Lib.Extensions;
 using Catalyst.Core.Lib.IO.Handlers;
 using Catalyst.Core.Lib.IO.Messaging.Correlation;
 using Catalyst.Core.Lib.IO.Messaging.Dto;
+using Catalyst.Core.Lib.Tests.Fakes;
 using Catalyst.Protocol.Wire;
 using Catalyst.Protocol.IPPN;
 using Catalyst.Protocol.Network;
@@ -58,16 +57,16 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
         private readonly EmbeddedChannel _serverChannel;
         private readonly EmbeddedChannel _clientChannel;
         private readonly IPeerMessageCorrelationManager _clientCorrelationManager;
-        private readonly IKeySigner _clientKeySigner;
+        private readonly FakeKeySigner _clientKeySigner;
         private readonly IPeerIdValidator _peerIdValidator;
-        private readonly IKeySigner _serverKeySigner;
+        private readonly FakeKeySigner _serverKeySigner;
         private readonly IPeerMessageCorrelationManager _serverCorrelationManager;
 
         public PeerServerChannelFactoryTests()
         {
             _testScheduler = new TestScheduler();
             _serverCorrelationManager = Substitute.For<IPeerMessageCorrelationManager>();
-            _serverKeySigner = Substitute.For<IKeySigner>();
+            _serverKeySigner = FakeKeySigner.SignOnly();
             var broadcastManager = Substitute.For<IBroadcastManager>();
 
             _peerIdValidator = Substitute.For<IPeerIdValidator>();
@@ -85,7 +84,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
                     _testScheduler);
 
             _clientCorrelationManager = Substitute.For<IPeerMessageCorrelationManager>();
-            _clientKeySigner = Substitute.For<IKeySigner>();
+            _clientKeySigner = FakeKeySigner.VerifyOnly();
 
             _clientFactory =
                 new UnitTests.P2P.IO.Transport.Channels.PeerClientChannelFactoryTests.TestPeerClientChannelFactory(
@@ -110,10 +109,8 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
             var recipient = PeerIdHelper.GetPeerId("recipient");
             var sender = PeerIdHelper.GetPeerId("sender");
 
-            var signature = Substitute.For<ISignature>();
             _peerIdValidator.ValidatePeerIdFormat(Arg.Any<PeerId>()).Returns(true);
             _serverKeySigner.CryptoContext.SignatureLength.Returns(64);
-            _serverKeySigner.Sign(Arg.Any<IMessage>(), default).ReturnsForAnyArgs(signature);
 
             var correlationId = CorrelationId.GenerateCorrelationId();
 
@@ -131,13 +128,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
             _serverCorrelationManager.DidNotReceiveWithAnyArgs()
                .AddPendingRequest(Arg.Any<CorrelatableMessage<ProtocolMessage>>());
 
-            _serverKeySigner.ReceivedWithAnyArgs(1).Sign(Arg.Any<IMessage>(), default);
-
-            _clientKeySigner.Verify(
-                    Arg.Any<ISignature>(),
-                    Arg.Any<IMessage>(),
-                    default)
-               .ReturnsForAnyArgs(true);
+            _serverKeySigner.SignCount.Should().Be(1);
 
             var observer = new ProtocolMessageObserver(0, Substitute.For<ILogger>());
 
@@ -150,7 +141,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
                 _clientChannel.ReadInbound<ProtocolMessage>();
                 _clientCorrelationManager.ReceivedWithAnyArgs(1).TryMatchResponse(Arg.Any<ProtocolMessage>());
 
-                _clientKeySigner.ReceivedWithAnyArgs(1).Verify(null, default(IMessage), null);
+                _clientKeySigner.VerifyCount.Should().Be(1);
 
                 _testScheduler.Start();
 

--- a/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/IO/Transport/Channels/PeerServerChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/IO/Transport/Channels/PeerServerChannelFactoryTests.cs
@@ -40,6 +40,7 @@ using Catalyst.TestUtils;
 using DotNetty.Transport.Channels.Embedded;
 using DotNetty.Transport.Channels.Sockets;
 using FluentAssertions;
+using Google.Protobuf;
 using Microsoft.Reactive.Testing;
 using NSubstitute;
 using Serilog;
@@ -112,7 +113,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
             var signature = Substitute.For<ISignature>();
             _peerIdValidator.ValidatePeerIdFormat(Arg.Any<PeerId>()).Returns(true);
             _serverKeySigner.CryptoContext.SignatureLength.Returns(64);
-            _serverKeySigner.Sign(Arg.Any<byte[]>(), default).ReturnsForAnyArgs(signature);
+            _serverKeySigner.Sign(Arg.Any<IMessage>(), default).ReturnsForAnyArgs(signature);
 
             var correlationId = CorrelationId.GenerateCorrelationId();
 
@@ -130,11 +131,11 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
             _serverCorrelationManager.DidNotReceiveWithAnyArgs()
                .AddPendingRequest(Arg.Any<CorrelatableMessage<ProtocolMessage>>());
 
-            _serverKeySigner.ReceivedWithAnyArgs(1).Sign(Arg.Any<byte[]>(), default);
+            _serverKeySigner.ReceivedWithAnyArgs(1).Sign(Arg.Any<IMessage>(), default);
 
             _clientKeySigner.Verify(
                     Arg.Any<ISignature>(),
-                    Arg.Any<byte[]>(),
+                    Arg.Any<IMessage>(),
                     default)
                .ReturnsForAnyArgs(true);
 
@@ -149,7 +150,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
                 _clientChannel.ReadInbound<ProtocolMessage>();
                 _clientCorrelationManager.ReceivedWithAnyArgs(1).TryMatchResponse(Arg.Any<ProtocolMessage>());
 
-                _clientKeySigner.ReceivedWithAnyArgs(1).Verify(null, default(byte[]), null);
+                _clientKeySigner.ReceivedWithAnyArgs(1).Verify(null, default(IMessage), null);
 
                 _testScheduler.Start();
 

--- a/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/IO/Transport/Channels/PeerServerChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/IO/Transport/Channels/PeerServerChannelFactoryTests.cs
@@ -149,7 +149,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
                 _clientChannel.ReadInbound<ProtocolMessage>();
                 _clientCorrelationManager.ReceivedWithAnyArgs(1).TryMatchResponse(Arg.Any<ProtocolMessage>());
 
-                _clientKeySigner.ReceivedWithAnyArgs(1).Verify(null, null, null);
+                _clientKeySigner.ReceivedWithAnyArgs(1).Verify(null, default(byte[]), null);
 
                 _testScheduler.Start();
 

--- a/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/PeerValidationIntegrationTest.cs
+++ b/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/PeerValidationIntegrationTest.cs
@@ -39,6 +39,8 @@ using Catalyst.Core.Lib.IO.EventLoop;
 using Catalyst.Core.Lib.P2P;
 using Catalyst.Core.Lib.P2P.IO.Transport.Channels;
 using Catalyst.Core.Lib.P2P.Protocols;
+using Catalyst.Core.Lib.Tests.Fakes;
+using Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels;
 using Catalyst.Core.Lib.Util;
 using Catalyst.Core.Modules.Cryptography.BulletProofs;
 using Catalyst.Core.Modules.Hashing;
@@ -96,10 +98,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P
                 UdpClientHandlerWorkerThreads = 5
             };
 
-            var keySigner = Substitute.For<IKeySigner>();
-            keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<byte[]>(), default).ReturnsForAnyArgs(true);
-            var signature = Substitute.For<ISignature>();
-            keySigner.Sign(Arg.Any<byte[]>(), default).ReturnsForAnyArgs(signature);
+            var keySigner = FakeKeySigner.SignAndVerify(true);
 
             _peerService = new PeerService(new UdpServerEventLoopGroupFactory(eventLoopGroupFactoryConfiguration),
                 new PeerServerChannelFactory(ContainerProvider.Container.Resolve<IPeerMessageCorrelationManager>(),

--- a/src/Catalyst.Core.Lib.Tests/IntegrationTests/Rpc/IO/Transport/Channels/RpcClientChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/IntegrationTests/Rpc/IO/Transport/Channels/RpcClientChannelFactoryTests.cs
@@ -155,7 +155,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
                 _serverChannel.WriteInbound(sentBytes);
                 _serverCorrelationManager.DidNotReceiveWithAnyArgs().TryMatchResponse(protocolMessage);
 
-                _serverKeySigner.ReceivedWithAnyArgs(1).Verify(null, null, null);
+                _serverKeySigner.ReceivedWithAnyArgs(1).Verify(null, default(byte[]), null);
 
                 _testScheduler.Start();
 

--- a/src/Catalyst.Core.Lib.Tests/IntegrationTests/Rpc/IO/Transport/Channels/RpcClientChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/IntegrationTests/Rpc/IO/Transport/Channels/RpcClientChannelFactoryTests.cs
@@ -23,8 +23,6 @@
 
 using System.Linq;
 using System.Threading.Tasks;
-using Catalyst.Abstractions.Cryptography;
-using Catalyst.Abstractions.KeySigner;
 using Catalyst.Abstractions.P2P;
 using Catalyst.Abstractions.Rpc.Authentication;
 using Catalyst.Abstractions.Rpc.IO.Messaging.Correlation;
@@ -32,6 +30,8 @@ using Catalyst.Core.Lib.Extensions;
 using Catalyst.Core.Lib.IO.Handlers;
 using Catalyst.Core.Lib.IO.Messaging.Correlation;
 using Catalyst.Core.Lib.IO.Messaging.Dto;
+using Catalyst.Core.Lib.Tests.Fakes;
+using Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels;
 using Catalyst.Core.Lib.Util;
 using Catalyst.Core.Modules.Cryptography.BulletProofs;
 using Catalyst.Protocol.Network;
@@ -42,7 +42,6 @@ using Catalyst.TestUtils;
 using DotNetty.Buffers;
 using DotNetty.Transport.Channels.Embedded;
 using FluentAssertions;
-using Google.Protobuf;
 using Microsoft.Reactive.Testing;
 using NSubstitute;
 using Serilog;
@@ -57,17 +56,17 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
         private readonly EmbeddedChannel _serverChannel;
         private readonly EmbeddedChannel _clientChannel;
         private readonly IRpcMessageCorrelationManager _clientCorrelationManager;
-        private readonly IKeySigner _clientKeySigner;
+        private readonly FakeKeySigner _clientKeySigner;
         private readonly IAuthenticationStrategy _authenticationStrategy;
         private readonly IPeerIdValidator _peerIdValidator;
-        private readonly IKeySigner _serverKeySigner;
+        private readonly FakeKeySigner _serverKeySigner;
         private readonly IRpcMessageCorrelationManager _serverCorrelationManager;
 
         public RpcClientChannelFactoryTests()
         {
             _testScheduler = new TestScheduler();
             _serverCorrelationManager = Substitute.For<IRpcMessageCorrelationManager>();
-            _serverKeySigner = Substitute.For<IKeySigner>();
+            _serverKeySigner = FakeKeySigner.VerifyOnly();
             _serverKeySigner.CryptoContext.SignatureLength.Returns(64);
 
             _authenticationStrategy = Substitute.For<IAuthenticationStrategy>();
@@ -85,7 +84,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
                 _testScheduler);
 
             _clientCorrelationManager = Substitute.For<IRpcMessageCorrelationManager>();
-            _clientKeySigner = Substitute.For<IKeySigner>();
+            _clientKeySigner = FakeKeySigner.SignOnly();
             _clientKeySigner.CryptoContext.SignatureLength.Returns(64);
             var clientFactory =
                 new UnitTests.Rpc.IO.Transport.Channels.RpcClientChannelFactoryTests.TestRpcClientChannelFactory(
@@ -109,12 +108,9 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
         {
             var recipient = PeerIdHelper.GetPeerId("recipient");
             var sender = PeerIdHelper.GetPeerId("sender");
-            var signature = Substitute.For<ISignature>();
-            signature.SignatureBytes.Returns(ByteUtil.GenerateRandomByteArray(new FfiWrapper().SignatureLength));
+            _clientKeySigner.Signature.SignatureBytes.Returns(ByteUtil.GenerateRandomByteArray(new FfiWrapper().SignatureLength));
 
             _peerIdValidator.ValidatePeerIdFormat(Arg.Any<PeerId>()).Returns(true);
-
-            _clientKeySigner.Sign(Arg.Any<IMessage>(), default).ReturnsForAnyArgs(signature);
 
             var correlationId = CorrelationId.GenerateCorrelationId();
 
@@ -135,14 +131,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
                 Arg.Is<CorrelatableMessage<ProtocolMessage>>(c =>
                     c.Content.CorrelationId.ToCorrelationId().Equals(correlationId)));
 
-            _clientKeySigner.ReceivedWithAnyArgs(1).Sign(default(IMessage), default);
-
-            _serverKeySigner.Verify(
-                    Arg.Any<ISignature>(),
-                    Arg.Any<IMessage>(),
-                    default
-                )
-               .ReturnsForAnyArgs(true);
+            _clientKeySigner.SignCount.Should().Be(1);
 
             _authenticationStrategy.Authenticate(Arg.Any<PeerId>()).Returns(true);
 
@@ -156,7 +145,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
                 _serverChannel.WriteInbound(sentBytes);
                 _serverCorrelationManager.DidNotReceiveWithAnyArgs().TryMatchResponse(protocolMessage);
 
-                _serverKeySigner.ReceivedWithAnyArgs(1).Verify(null, default(IMessage), null);
+                _serverKeySigner.VerifyCount.Should().Be(1);
 
                 _testScheduler.Start();
 

--- a/src/Catalyst.Core.Lib.Tests/IntegrationTests/Rpc/IO/Transport/Channels/RpcServerChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/IntegrationTests/Rpc/IO/Transport/Channels/RpcServerChannelFactoryTests.cs
@@ -147,7 +147,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
                 _clientChannel.ReadInbound<ProtocolMessage>();
                 _clientCorrelationManager.ReceivedWithAnyArgs(1).TryMatchResponse(Arg.Any<ProtocolMessage>());
                 
-                _clientKeySigner.ReceivedWithAnyArgs(1).Verify(null, null, null);
+                _clientKeySigner.ReceivedWithAnyArgs(1).Verify(null, default(byte[]), null);
 
                 _testScheduler.Start();
 

--- a/src/Catalyst.Core.Lib.Tests/IntegrationTests/Rpc/IO/Transport/Channels/RpcServerChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/IntegrationTests/Rpc/IO/Transport/Channels/RpcServerChannelFactoryTests.cs
@@ -40,6 +40,7 @@ using Catalyst.TestUtils;
 using DotNetty.Buffers;
 using DotNetty.Transport.Channels.Embedded;
 using FluentAssertions;
+using Google.Protobuf;
 using Microsoft.Reactive.Testing;
 using NSubstitute;
 using Serilog;
@@ -109,7 +110,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
             var signature = Substitute.For<ISignature>();
             _peerIdValidator.ValidatePeerIdFormat(Arg.Any<PeerId>()).Returns(true);
             
-            _serverKeySigner.Sign(Arg.Any<byte[]>(), default).ReturnsForAnyArgs(signature);
+            _serverKeySigner.Sign(Arg.Any<IMessage>(), default).ReturnsForAnyArgs(signature);
             
             var correlationId = CorrelationId.GenerateCorrelationId();
 
@@ -127,11 +128,11 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
             _serverCorrelationManager.DidNotReceiveWithAnyArgs().AddPendingRequest(Arg.Any<CorrelatableMessage<ProtocolMessage>>());
             
             _serverKeySigner.ReceivedWithAnyArgs(1)
-               .Sign(Arg.Any<byte[]>(), default);
+               .Sign(Arg.Any<IMessage>(), default);
             
             _clientKeySigner.Verify(
                     Arg.Any<ISignature>(),
-                    Arg.Any<byte[]>(), 
+                    Arg.Any<IMessage>(), 
                     default)
                .ReturnsForAnyArgs(true);
             
@@ -147,7 +148,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
                 _clientChannel.ReadInbound<ProtocolMessage>();
                 _clientCorrelationManager.ReceivedWithAnyArgs(1).TryMatchResponse(Arg.Any<ProtocolMessage>());
                 
-                _clientKeySigner.ReceivedWithAnyArgs(1).Verify(null, default(byte[]), null);
+                _clientKeySigner.ReceivedWithAnyArgs(1).Verify(null, default(IMessage), null);
 
                 _testScheduler.Start();
 

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/IO/Handlers/ProtocolMessageVerifyHandlerTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/IO/Handlers/ProtocolMessageVerifyHandlerTests.cs
@@ -32,6 +32,7 @@ using Catalyst.Protocol.Wire;
 using Catalyst.TestUtils;
 using Catalyst.TestUtils.Protocol;
 using DotNetty.Transport.Channels;
+using Google.Protobuf;
 using NSubstitute;
 using Xunit;
 
@@ -62,7 +63,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.IO.Handlers
         [Fact]
         private void CanFireNextPipelineOnValidSignature()
         {
-            _keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<byte[]>(), default)
+            _keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<IMessage>(), default)
                .ReturnsForAnyArgs(true);
 
             var signatureHandler = new ProtocolMessageVerifyHandler(_keySigner);
@@ -75,7 +76,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.IO.Handlers
         [Fact]
         private void CanFireNextPipelineOnInvalidSignature()
         {
-            _keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<byte[]>(), default)
+            _keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<IMessage>(), default)
                .ReturnsForAnyArgs(false);
 
             var signatureHandler = new ProtocolMessageVerifyHandler(_keySigner);

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/IO/Handlers/ProtocolMessageVerifyHandlerTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/IO/Handlers/ProtocolMessageVerifyHandlerTests.cs
@@ -24,6 +24,8 @@
 using Catalyst.Abstractions.Cryptography;
 using Catalyst.Abstractions.KeySigner;
 using Catalyst.Core.Lib.IO.Handlers;
+using Catalyst.Core.Lib.Tests.Fakes;
+using Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels;
 using Catalyst.Core.Lib.Util;
 using Catalyst.Core.Modules.Cryptography.BulletProofs;
 using Catalyst.Protocol.Cryptography;
@@ -42,13 +44,11 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.IO.Handlers
     {
         private readonly IChannelHandlerContext _fakeContext;
         private readonly ProtocolMessage _protocolMessageSigned;
-        private readonly IKeySigner _keySigner;
         private readonly SigningContext _signingContext;
 
         public ProtocolMessageVerifyHandlerTests()
         {
             _fakeContext = Substitute.For<IChannelHandlerContext>();
-            _keySigner = Substitute.For<IKeySigner>();
             _signingContext = DevNetPeerSigningContext.Instance;
 
             var signatureBytes = ByteUtil.GenerateRandomByteArray(new FfiWrapper().SignatureLength);
@@ -63,10 +63,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.IO.Handlers
         [Fact]
         private void CanFireNextPipelineOnValidSignature()
         {
-            _keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<IMessage>(), default)
-               .ReturnsForAnyArgs(true);
-
-            var signatureHandler = new ProtocolMessageVerifyHandler(_keySigner);
+            var signatureHandler = new ProtocolMessageVerifyHandler(FakeKeySigner.VerifyOnly());
 
             signatureHandler.ChannelRead(_fakeContext, _protocolMessageSigned);
 
@@ -76,10 +73,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.IO.Handlers
         [Fact]
         private void CanFireNextPipelineOnInvalidSignature()
         {
-            _keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<IMessage>(), default)
-               .ReturnsForAnyArgs(false);
-
-            var signatureHandler = new ProtocolMessageVerifyHandler(_keySigner);
+            var signatureHandler = new ProtocolMessageVerifyHandler(FakeKeySigner.VerifyOnly(false));
 
             signatureHandler.ChannelRead(_fakeContext, _protocolMessageSigned);
             

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Messaging/Broadcast/BroadcastHandlerTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Messaging/Broadcast/BroadcastHandlerTests.cs
@@ -26,6 +26,8 @@ using Catalyst.Abstractions.Cryptography;
 using Catalyst.Abstractions.KeySigner;
 using Catalyst.Abstractions.P2P.IO.Messaging.Broadcast;
 using Catalyst.Core.Lib.IO.Handlers;
+using Catalyst.Core.Lib.Tests.Fakes;
+using Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels;
 using Catalyst.Core.Lib.Util;
 using Catalyst.Core.Modules.Cryptography.BulletProofs;
 using Catalyst.Protocol.Cryptography;
@@ -46,14 +48,13 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Messaging.Broadcast
     {
         private readonly IBroadcastManager _fakeBroadcastManager;
         private readonly BroadcastHandler _broadcastHandler;
-        private readonly IKeySigner _keySigner;
+        private readonly FakeKeySigner _keySigner;
         private readonly ProtocolMessage _broadcastMessageSigned;
         private readonly SigningContext _signingContext;
 
         public BroadcastHandlerTests()
         {
-            _keySigner = Substitute.For<IKeySigner>();
-            _keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<IMessage>(), default).ReturnsForAnyArgs(true);
+            _keySigner = FakeKeySigner.VerifyOnly();
             _fakeBroadcastManager = Substitute.For<IBroadcastManager>();
             _broadcastHandler = new BroadcastHandler(_fakeBroadcastManager);
 

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Messaging/Broadcast/BroadcastHandlerTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Messaging/Broadcast/BroadcastHandlerTests.cs
@@ -33,6 +33,7 @@ using Catalyst.Protocol.Wire;
 using Catalyst.TestUtils;
 using Catalyst.TestUtils.Protocol;
 using DotNetty.Transport.Channels.Embedded;
+using Google.Protobuf;
 using Microsoft.Reactive.Testing;
 using NSubstitute;
 using NSubstitute.ReceivedExtensions;
@@ -52,7 +53,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Messaging.Broadcast
         public BroadcastHandlerTests()
         {
             _keySigner = Substitute.For<IKeySigner>();
-            _keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<byte[]>(), default).ReturnsForAnyArgs(true);
+            _keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<IMessage>(), default).ReturnsForAnyArgs(true);
             _fakeBroadcastManager = Substitute.For<IBroadcastManager>();
             _broadcastHandler = new BroadcastHandler(_fakeBroadcastManager);
 

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Messaging/Broadcast/BroadcastManagerTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Messaging/Broadcast/BroadcastManagerTests.cs
@@ -34,6 +34,8 @@ using Catalyst.Core.Lib.IO.Messaging.Dto;
 using Catalyst.Core.Lib.P2P.IO.Messaging.Broadcast;
 using Catalyst.Core.Lib.P2P.Models;
 using Catalyst.Core.Lib.P2P.Repository;
+using Catalyst.Core.Lib.Tests.Fakes;
+using Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels;
 using Catalyst.Protocol.Peer;
 using Catalyst.TestUtils;
 using FluentAssertions;
@@ -49,16 +51,14 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Messaging.Broadcast
     {
         private readonly IPeerRepository _peers;
         private readonly IMemoryCache _cache;
-        private readonly IKeySigner _keySigner;
+        private readonly FakeKeySigner _keySigner;
         private readonly PeerId _senderPeerId;
         private readonly IPeerSettings _peerSettings;
 
         public BroadcastManagerTests()
         {
             _senderPeerId = PeerIdHelper.GetPeerId("sender");
-            _keySigner = Substitute.For<IKeySigner>();
-            var fakeSignature = Substitute.For<ISignature>();
-            _keySigner.Sign(Arg.Any<byte[]>(), default).ReturnsForAnyArgs(fakeSignature);
+            _keySigner = FakeKeySigner.SignOnly();
             _keySigner.CryptoContext.SignatureLength.Returns(64);
             _peers = new PeerRepository(new InMemoryRepository<Peer, string>());
             _cache = new MemoryCache(new MemoryCacheOptions());

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Transport/Channels/PeerClientChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Transport/Channels/PeerClientChannelFactoryTests.cs
@@ -136,7 +136,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Transport.Channels
                 testingChannel.WriteInbound(signedMessage);
                 _correlationManager.DidNotReceiveWithAnyArgs().TryMatchResponse(protocolMessage);
                 await _gossipManager.DidNotReceiveWithAnyArgs().BroadcastAsync(null);
-                _keySigner.ReceivedWithAnyArgs(1).Verify(null, null, null);
+                _keySigner.ReceivedWithAnyArgs(1).Verify(null, default(byte[]), null);
 
                 _testScheduler.Start();
 

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Transport/Channels/PeerServerChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Transport/Channels/PeerServerChannelFactoryTests.cs
@@ -44,6 +44,7 @@ using Catalyst.TestUtils;
 using DotNetty.Transport.Channels;
 using DotNetty.Transport.Channels.Embedded;
 using FluentAssertions;
+using Google.Protobuf;
 using Microsoft.Reactive.Testing;
 using NSubstitute;
 using Serilog;
@@ -103,7 +104,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Transport.Channels
             _senderId = PeerIdHelper.GetPeerId("sender");
             _correlationId = CorrelationId.GenerateCorrelationId();
             _signature = ByteUtil.GenerateRandomByteArray(new FfiWrapper().SignatureLength);
-            _keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<byte[]>(), default)
+            _keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<IMessage>(), default)
                .ReturnsForAnyArgs(true);
         }
 
@@ -141,7 +142,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Transport.Channels
                 _correlationManager.DidNotReceiveWithAnyArgs().TryMatchResponse(protocolMessage);
                 await _gossipManager.DidNotReceiveWithAnyArgs().BroadcastAsync(null);
 
-                _keySigner.ReceivedWithAnyArgs(1).Verify(null, default(byte[]), null);
+                _keySigner.ReceivedWithAnyArgs(1).Verify(null, default(IMessage), null);
 
                 _testScheduler.Start();
 

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Transport/Channels/PeerServerChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Transport/Channels/PeerServerChannelFactoryTests.cs
@@ -34,6 +34,8 @@ using Catalyst.Core.Lib.Extensions;
 using Catalyst.Core.Lib.IO.Handlers;
 using Catalyst.Core.Lib.IO.Messaging.Correlation;
 using Catalyst.Core.Lib.P2P.IO.Transport.Channels;
+using Catalyst.Core.Lib.Tests.Fakes;
+using Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels;
 using Catalyst.Core.Lib.Util;
 using Catalyst.Core.Modules.Cryptography.BulletProofs;
 using Catalyst.Protocol.Wire;
@@ -76,7 +78,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Transport.Channels
         private readonly TestScheduler _testScheduler;
         private readonly IPeerMessageCorrelationManager _correlationManager;
         private readonly IBroadcastManager _gossipManager;
-        private readonly IKeySigner _keySigner;
+        private readonly FakeKeySigner _keySigner;
         private readonly TestPeerServerChannelFactory _factory;
         private readonly PeerId _senderId;
         private readonly ICorrelationId _correlationId;
@@ -87,7 +89,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Transport.Channels
             _testScheduler = new TestScheduler();
             _correlationManager = Substitute.For<IPeerMessageCorrelationManager>();
             _gossipManager = Substitute.For<IBroadcastManager>();
-            _keySigner = Substitute.For<IKeySigner>();
+            _keySigner = FakeKeySigner.VerifyOnly();
 
             var peerSettings = Substitute.For<IPeerSettings>();
             peerSettings.NetworkType.Returns(NetworkType.Devnet);
@@ -104,8 +106,6 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Transport.Channels
             _senderId = PeerIdHelper.GetPeerId("sender");
             _correlationId = CorrelationId.GenerateCorrelationId();
             _signature = ByteUtil.GenerateRandomByteArray(new FfiWrapper().SignatureLength);
-            _keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<IMessage>(), default)
-               .ReturnsForAnyArgs(true);
         }
 
         [Fact]
@@ -142,7 +142,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Transport.Channels
                 _correlationManager.DidNotReceiveWithAnyArgs().TryMatchResponse(protocolMessage);
                 await _gossipManager.DidNotReceiveWithAnyArgs().BroadcastAsync(null);
 
-                _keySigner.ReceivedWithAnyArgs(1).Verify(null, default(IMessage), null);
+                _keySigner.VerifyCount.Should().Be(1);
 
                 _testScheduler.Start();
 

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Transport/Channels/PeerServerChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Transport/Channels/PeerServerChannelFactoryTests.cs
@@ -141,7 +141,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Transport.Channels
                 _correlationManager.DidNotReceiveWithAnyArgs().TryMatchResponse(protocolMessage);
                 await _gossipManager.DidNotReceiveWithAnyArgs().BroadcastAsync(null);
 
-                _keySigner.ReceivedWithAnyArgs(1).Verify(null, null, null);
+                _keySigner.ReceivedWithAnyArgs(1).Verify(null, default(byte[]), null);
 
                 _testScheduler.Start();
 

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Observers/SignMessageRequestObserverTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Observers/SignMessageRequestObserverTests.cs
@@ -60,7 +60,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Observers
             var fakeChannel = Substitute.For<IChannel>();
             _fakeContext.Channel.Returns(fakeChannel);
 
-            _keySigner.Sign(default, default).ReturnsForAnyArgs(_signature);
+            _keySigner.Sign(default(byte[]), default).ReturnsForAnyArgs(_signature);
         }
 
         [Theory]

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Observers/SignMessageRequestObserverTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Observers/SignMessageRequestObserverTests.cs
@@ -26,6 +26,8 @@ using Catalyst.Abstractions.Cryptography;
 using Catalyst.Abstractions.IO.Messaging.Dto;
 using Catalyst.Abstractions.KeySigner;
 using Catalyst.Core.Lib.Extensions;
+using Catalyst.Core.Lib.Tests.Fakes;
+using Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels;
 using Catalyst.Core.Lib.Util;
 using Catalyst.Core.Modules.Cryptography.BulletProofs;
 using Catalyst.Core.Modules.Rpc.Server.IO.Observers;
@@ -45,22 +47,18 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Observers
     public sealed class SignMessageRequestObserverTests
     {
         private readonly ILogger _logger;
-        private readonly IKeySigner _keySigner;
+        private readonly FakeKeySigner _keySigner;
         private readonly IChannelHandlerContext _fakeContext;
-        private readonly ISignature _signature;
 
         public SignMessageRequestObserverTests()
         {
-            _keySigner = Substitute.For<IKeySigner>();
-            _signature = Substitute.For<ISignature>();
-            _signature.SignatureBytes.Returns(ByteUtil.GenerateRandomByteArray(new FfiWrapper().SignatureLength));
-            _signature.PublicKeyBytes.Returns(ByteUtil.GenerateRandomByteArray(new FfiWrapper().PublicKeyLength));
+            _keySigner = FakeKeySigner.SignOnly();
+            _keySigner.Signature.SignatureBytes.Returns(ByteUtil.GenerateRandomByteArray(new FfiWrapper().SignatureLength));
+            _keySigner.Signature.PublicKeyBytes.Returns(ByteUtil.GenerateRandomByteArray(new FfiWrapper().PublicKeyLength));
             _logger = Substitute.For<ILogger>();
             _fakeContext = Substitute.For<IChannelHandlerContext>();
             var fakeChannel = Substitute.For<IChannel>();
             _fakeContext.Channel.Returns(fakeChannel);
-
-            _keySigner.Sign(default(byte[]), default).ReturnsForAnyArgs(_signature);
         }
 
         [Theory]
@@ -97,8 +95,8 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Observers
             var signResponseMessage = sentResponseDto.Content.FromProtocolMessage<SignMessageResponse>();
 
             signResponseMessage.OriginalMessage.Should().Equal(message);
-            signResponseMessage.Signature.ToByteArray().Should().Equal(_signature.SignatureBytes);
-            signResponseMessage.PublicKey.ToByteArray().Should().Equal(_signature.PublicKeyBytes);
+            signResponseMessage.Signature.ToByteArray().Should().Equal(_keySigner.Signature.SignatureBytes);
+            signResponseMessage.PublicKey.ToByteArray().Should().Equal(_keySigner.Signature.PublicKeyBytes);
         }
     }
 }

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Observers/VerifyMessageRequestObserverTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Observers/VerifyMessageRequestObserverTests.cs
@@ -93,14 +93,14 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Observers
         [Fact]
         public void VerifyMessageRequestObserver_Can_Send_True_If_Valid_Signature()
         {
-            _keySigner.Verify(default, default, default).ReturnsForAnyArgs(true);
+            _keySigner.Verify(default, default(byte[]), default).ReturnsForAnyArgs(true);
             AssertVerifyResponse(true);
         }
 
         [Fact]
         public void VerifyMessageRequestObserver_Can_Send_False_Response_If_Verify_Fails()
         {
-            _keySigner.Verify(default, default, default).ReturnsForAnyArgs(false);
+            _keySigner.Verify(default, default(byte[]), default).ReturnsForAnyArgs(false);
             AssertVerifyResponse(false);
         }
 

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Observers/VerifyMessageRequestObserverTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Observers/VerifyMessageRequestObserverTests.cs
@@ -34,6 +34,8 @@ using NSubstitute;
 using Serilog;
 using System.Linq;
 using Catalyst.Core.Lib.IO.Messaging.Dto;
+using Catalyst.Core.Lib.Tests.Fakes;
+using Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels;
 using Catalyst.Protocol.Cryptography;
 using Catalyst.Protocol.Network;
 using Catalyst.Protocol.Peer;
@@ -43,7 +45,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Observers
 {
     public sealed class VerifyMessageRequestObserverTests
     {
-        private readonly IKeySigner _keySigner;
+        private readonly FakeKeySigner _keySigner;
         private readonly VerifyMessageRequestObserver _verifyMessageRequestObserver;
         private readonly IChannelHandlerContext _fakeContext;
         private readonly PeerId _testPeerId;
@@ -62,8 +64,8 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Observers
 
             var peerSettings = _testPeerId.ToSubstitutedPeerSettings();
 
-            _keySigner = Substitute.For<IKeySigner>();
-            _keySigner.CryptoContext.Returns(new FfiWrapper());
+            _keySigner = FakeKeySigner.SignAndVerify();
+            _keySigner.CryptoContext = new FfiWrapper();
 
             var logger = Substitute.For<ILogger>();
             _fakeContext = Substitute.For<IChannelHandlerContext>();
@@ -93,14 +95,14 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Observers
         [Fact]
         public void VerifyMessageRequestObserver_Can_Send_True_If_Valid_Signature()
         {
-            _keySigner.Verify(default, default(byte[]), default).ReturnsForAnyArgs(true);
+            _keySigner.EnableVerification(true);
             AssertVerifyResponse(true);
         }
 
         [Fact]
         public void VerifyMessageRequestObserver_Can_Send_False_Response_If_Verify_Fails()
         {
-            _keySigner.Verify(default, default(byte[]), default).ReturnsForAnyArgs(false);
+            _keySigner.EnableVerification(false);
             AssertVerifyResponse(false);
         }
 

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Transport/Channels/RpcClientChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Transport/Channels/RpcClientChannelFactoryTests.cs
@@ -44,6 +44,7 @@ using DotNetty.Codecs.Protobuf;
 using DotNetty.Transport.Channels;
 using DotNetty.Transport.Channels.Embedded;
 using FluentAssertions;
+using Google.Protobuf;
 using Microsoft.Reactive.Testing;
 using NSubstitute;
 using Serilog;
@@ -121,7 +122,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Transport.Channels
             var protocolMessage = new PingResponse()
                .ToSignedProtocolMessage(senderId, signatureBytes, correlationId: correlationId);
 
-            _keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<byte[]>(), Arg.Any<SigningContext>())
+            _keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<IMessage>(), Arg.Any<SigningContext>())
                .Returns(true);
 
             _correlationManager.TryMatchResponse(protocolMessage).Returns(true);
@@ -136,7 +137,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Transport.Channels
 
                 _correlationManager.Received(1).TryMatchResponse(protocolMessage);
 
-                _keySigner.ReceivedWithAnyArgs(1).Verify(null, default(byte[]), null);
+                _keySigner.ReceivedWithAnyArgs(1).Verify(null, default(IMessage), null);
 
                 _testScheduler.Start();
 
@@ -160,6 +161,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Transport.Channels
             _correlationManager.DidNotReceiveWithAnyArgs().TryMatchResponse(default);
             
             _keySigner.DidNotReceiveWithAnyArgs().Sign(Arg.Any<byte[]>(), default);
+            _keySigner.DidNotReceiveWithAnyArgs().Sign(Arg.Any<IMessage>(), default);
 
             testingChannel.ReadOutbound<IByteBuffer>();
         }

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Transport/Channels/RpcClientChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Transport/Channels/RpcClientChannelFactoryTests.cs
@@ -136,7 +136,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Transport.Channels
 
                 _correlationManager.Received(1).TryMatchResponse(protocolMessage);
 
-                _keySigner.ReceivedWithAnyArgs(1).Verify(null, null, null);
+                _keySigner.ReceivedWithAnyArgs(1).Verify(null, default(byte[]), null);
 
                 _testScheduler.Start();
 

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Transport/Channels/RpcServerChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Transport/Channels/RpcServerChannelFactoryTests.cs
@@ -140,7 +140,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Transport.Channels
             {
                 testingChannel.WriteInbound(protocolMessage);
                 _correlationManager.DidNotReceiveWithAnyArgs().TryMatchResponse(protocolMessage);
-                _keySigner.ReceivedWithAnyArgs(1).Verify(null, null, null);
+                _keySigner.ReceivedWithAnyArgs(1).Verify(null, default(byte[]), null);
                 _testScheduler.Start();
                 observer.Received.Count.Should().Be(1);
                 observer.Received.Single().Payload.CorrelationId.ToCorrelationId().Id.Should().Be(correlationId.Id);

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Transport/Channels/RpcServerChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Transport/Channels/RpcServerChannelFactoryTests.cs
@@ -32,6 +32,8 @@ using Catalyst.Core.Lib.Extensions;
 using Catalyst.Core.Lib.IO.Codecs;
 using Catalyst.Core.Lib.IO.Handlers;
 using Catalyst.Core.Lib.IO.Messaging.Correlation;
+using Catalyst.Core.Lib.Tests.Fakes;
+using Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels;
 using Catalyst.Core.Lib.Util;
 using Catalyst.Core.Modules.Cryptography.BulletProofs;
 using Catalyst.Core.Modules.Rpc.Server.Transport.Channels;
@@ -76,13 +78,13 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Transport.Channels
         private readonly TestScheduler _testScheduler;
         private readonly IRpcMessageCorrelationManager _correlationManager;
         private readonly TestRpcServerChannelFactory _factory;
-        private readonly IKeySigner _keySigner;
+        private readonly FakeKeySigner _keySigner;
 
         public RpcServerChannelFactoryTests()
         {
             _testScheduler = new TestScheduler();
             _correlationManager = Substitute.For<IRpcMessageCorrelationManager>();
-            _keySigner = Substitute.For<IKeySigner>();
+            _keySigner = FakeKeySigner.VerifyOnly();
             _keySigner.CryptoContext.SignatureLength.Returns(64);
 
             var authenticationStrategy = Substitute.For<IAuthenticationStrategy>();
@@ -128,8 +130,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Transport.Channels
             var senderId = PeerIdHelper.GetPeerId("sender");
             var correlationId = CorrelationId.GenerateCorrelationId();
             var signatureBytes = ByteUtil.GenerateRandomByteArray(new FfiWrapper().SignatureLength);
-            _keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<IMessage>(), Arg.Any<SigningContext>())
-               .Returns(true);
+        
             var protocolMessage = new PingRequest().ToSignedProtocolMessage(senderId, signatureBytes, correlationId: correlationId);
 
             var observer = new ProtocolMessageObserver(0, Substitute.For<ILogger>());
@@ -141,7 +142,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Transport.Channels
             {
                 testingChannel.WriteInbound(protocolMessage);
                 _correlationManager.DidNotReceiveWithAnyArgs().TryMatchResponse(protocolMessage);
-                _keySigner.ReceivedWithAnyArgs(1).Verify(null, default(IMessage), null);
+                _keySigner.VerifyCount.Should().Be(1);
                 _testScheduler.Start();
                 observer.Received.Count.Should().Be(1);
                 observer.Received.Single().Payload.CorrelationId.ToCorrelationId().Id.Should().Be(correlationId.Id);
@@ -162,9 +163,6 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Transport.Channels
 
             _correlationManager.DidNotReceiveWithAnyArgs().TryMatchResponse(protocolMessage);
             
-            _keySigner.DidNotReceiveWithAnyArgs().Sign(Arg.Any<byte[]>(), default);
-            _keySigner.DidNotReceiveWithAnyArgs().Sign(Arg.Any<IMessage>(), default);
-
             testingChannel.ReadOutbound<IByteBuffer>();
         }
     }

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/Validators/TransactionValidatorTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/Validators/TransactionValidatorTests.cs
@@ -156,19 +156,5 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Validators
             var result = transactionValidator.ValidateTransaction(validTransactionBroadcast);
             result.Should().BeFalse();
         }
-
-        class StubMessage : IMessage
-        {
-            public void MergeFrom(CodedInputStream input) { throw new System.NotImplementedException(); }
-
-            public void WriteTo(CodedOutputStream output)
-            {
-                output.WriteTag(1, WireFormat.WireType.Varint);
-                output.WriteInt32(1);
-            }
-
-            public int CalculateSize() => 2;
-            public MessageDescriptor Descriptor => throw new System.NotImplementedException();
-        }
     }
 }

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/Validators/TransactionValidatorTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/Validators/TransactionValidatorTests.cs
@@ -21,6 +21,7 @@
 
 #endregion
 
+using System;
 using Catalyst.Abstractions.Cryptography;
 using Catalyst.Core.Lib.Extensions;
 using Catalyst.Core.Lib.Validators;
@@ -29,8 +30,6 @@ using Catalyst.Protocol.Network;
 using Catalyst.Protocol.Transaction;
 using Catalyst.Protocol.Wire;
 using FluentAssertions;
-using Google.Protobuf;
-using Google.Protobuf.Reflection;
 using NSubstitute;
 using Serilog;
 using Xunit;
@@ -62,19 +61,13 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Validators
             TransactionValidator_ValidateTransactionSignature_returns_true_for_valid_transaction_signature_verification()
         {
             var subbedLogger = Substitute.For<ILogger>();
-            var subbedContext = Substitute.For<ICryptoContext>();
+            var signatureResult = Substitute.For<ISignature>();
+            var subbedContext = new FakeContext(signatureResult, true);
 
-            subbedContext.GetSignatureFromBytes(Arg.Any<byte[]>(), Arg.Any<byte[]>())
-               .ReturnsForAnyArgs(Substitute.For<ISignature>());
-
-            subbedContext.Verify(Arg.Any<ISignature>(), Arg.Any<byte[]>(), Arg.Any<int>(), Arg.Any<byte[]>(), Arg.Any<int>())
-               .Returns(true);
-
-            subbedContext.Sign(Arg.Any<IPrivateKey>(), Arg.Any<byte[]>(), Arg.Any<int>(), Arg.Any<byte[]>(), Arg.Any<int>())
-               .SignatureBytes.Returns(new byte[64]);
+            signatureResult.SignatureBytes.Returns(new byte[64]);
 
             var transactionValidator = new TransactionValidator(subbedLogger, subbedContext);
-            var privateKey = subbedContext.GeneratePrivateKey();
+            var privateKey = Substitute.For<IPrivateKey>();
 
             var validTransactionBroadcast = new TransactionBroadcast
             {
@@ -106,14 +99,17 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Validators
             var result = transactionValidator.ValidateTransaction(validTransactionBroadcast);
             result.Should().BeTrue();
         }
-        
+
         [Fact]
         public void TransactionValidator_ValidateTransactionSignature_returns_false_for_invalid_transaction_signature_verification()
         {
             var subbedLogger = Substitute.For<ILogger>();
-            var subbedContext = Substitute.For<ICryptoContext>();
-            
-            var privateKey = subbedContext.GeneratePrivateKey();
+            var signatureResult = Substitute.For<ISignature>();
+            var subbedContext = new FakeContext(signatureResult, false);
+
+            signatureResult.SignatureBytes.Returns(new byte[64]);
+
+            var privateKey = Substitute.For<IPrivateKey>();
 
             // raw un-signed tx message
             var validTransactionBroadcast = new TransactionBroadcast
@@ -139,22 +135,40 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Validators
                     SignatureType = SignatureType.TransactionPublic
                 }
             };
-            
-            subbedContext.GetSignatureFromBytes(Arg.Is(txSig.ToByteArray()), Arg.Is(privateKey.GetPublicKey().Bytes))
-               .ReturnsForAnyArgs(Substitute.For<ISignature>());
 
-            subbedContext.Verify(Arg.Any<ISignature>(), Arg.Any<byte[]>(), Arg.Any<int>(), Arg.Any<byte[]>(), Arg.Any<int>())
-               .Returns(false);
-
-            subbedContext.Sign(Arg.Is(privateKey), validTransactionBroadcast, txSig.SigningContext)
-               .SignatureBytes.Returns(new byte[64]);
-            
             var transactionValidator = new TransactionValidator(subbedLogger, subbedContext);
 
             validTransactionBroadcast.Signature = txSig;
 
             var result = transactionValidator.ValidateTransaction(validTransactionBroadcast);
             result.Should().BeFalse();
+        }
+
+        sealed class FakeContext : ICryptoContext
+        {
+            readonly ISignature _signature;
+            readonly bool _verifyResult;
+
+            public FakeContext(ISignature signature, bool verifyResult)
+            {
+                _signature = signature;
+                _verifyResult = verifyResult;
+            }
+
+            public int PrivateKeyLength { get; }
+            public int PublicKeyLength { get; }
+            public int SignatureLength { get; }
+            public int SignatureContextMaxLength { get; }
+            public IPrivateKey GeneratePrivateKey() { throw new NotImplementedException(); }
+            public IPublicKey GetPublicKeyFromPrivateKey(IPrivateKey privateKey) { throw new NotImplementedException(); }
+            public IPublicKey GetPublicKeyFromBytes(byte[] publicKeyBytes) { throw new NotImplementedException(); }
+            public IPrivateKey GetPrivateKeyFromBytes(byte[] privateKeyBytes) { throw new NotImplementedException(); }
+            public byte[] ExportPrivateKey(IPrivateKey privateKey) { throw new NotImplementedException(); }
+            public byte[] ExportPublicKey(IPublicKey publicKey) { throw new NotImplementedException(); }
+            
+            public ISignature Sign(IPrivateKey privateKey, ReadOnlySpan<byte> message, ReadOnlySpan<byte> context) => _signature;
+            public ISignature GetSignatureFromBytes(byte[] signatureBytes, byte[] publicKeyBytes) => Substitute.For<ISignature>();
+            public bool Verify(ISignature signature, ReadOnlySpan<byte> message, ReadOnlySpan<byte> context) => _verifyResult;
         }
     }
 }

--- a/src/Catalyst.Core.Lib/Extensions/Protocol/Wire/ProtocolMessageExtensions.cs
+++ b/src/Catalyst.Core.Lib/Extensions/Protocol/Wire/ProtocolMessageExtensions.cs
@@ -52,7 +52,7 @@ namespace Catalyst.Core.Lib.Extensions.Protocol.Wire
             }
 
             protocolMessage.Signature = null;
-            var signatureBytes = keySigner.Sign(protocolMessage.ToByteArray(),
+            var signatureBytes = keySigner.Sign(protocolMessage,
                 signingContext).SignatureBytes;
             var signature = new Signature
             {

--- a/src/Catalyst.Core.Lib/Extensions/Protocol/Wire/TransactionBroadcastExtensions.cs
+++ b/src/Catalyst.Core.Lib/Extensions/Protocol/Wire/TransactionBroadcastExtensions.cs
@@ -56,8 +56,7 @@ namespace Catalyst.Core.Lib.Extensions.Protocol.Wire
             }
 
             clone.Signature = null;
-            var signatureBytes = cryptoContext.Sign(privateKey, clone.ToByteArray(),
-                context.ToByteArray()).SignatureBytes;
+            var signatureBytes = cryptoContext.Sign(privateKey, clone, context).SignatureBytes;
 
             clone.Signature = new Signature
             {

--- a/src/Catalyst.Core.Lib/IO/Handlers/ProtocolMessageVerifyHandler.cs
+++ b/src/Catalyst.Core.Lib/IO/Handlers/ProtocolMessageVerifyHandler.cs
@@ -76,8 +76,7 @@ namespace Catalyst.Core.Lib.IO.Handlers
             var messageWithoutSig = signedMessage.Clone();
             messageWithoutSig.Signature = null;
 
-            return _keySigner.Verify(signature, messageWithoutSig.ToByteArray(),
-                signedMessage.Signature.SigningContext);
+            return _keySigner.Verify(signature, messageWithoutSig, signedMessage.Signature.SigningContext);
         }
     }
 }

--- a/src/Catalyst.Core.Lib/Validators/TransactionValidator.cs
+++ b/src/Catalyst.Core.Lib/Validators/TransactionValidator.cs
@@ -59,14 +59,14 @@ namespace Catalyst.Core.Lib.Validators
             var transactionSignature = _cryptoContext.GetSignatureFromBytes(transactionBroadcast.Signature.RawBytes.ToByteArray(),
                 transactionBroadcast.PublicEntries.First().Base.SenderPublicKey.ToByteArray());
 
-            var signingContext = transactionBroadcast.Signature.SigningContext.ToByteArray();
+            var signingContext = transactionBroadcast.Signature.SigningContext;
 
             // we need to verify the signature matches the message, but transactionBroadcast contains the signature and original data,
             // passing message+sig will mean your verifying an incorrect message and always return false, so just null the sig.
             var transactionBroadcastClone = transactionBroadcast.Clone();
             transactionBroadcastClone.Signature = null;
 
-            if (_cryptoContext.Verify(transactionSignature, transactionBroadcastClone.ToByteArray(), signingContext))
+            if (_cryptoContext.Verify(transactionSignature, transactionBroadcastClone, signingContext))
             {
                 return true;
             }

--- a/src/Catalyst.Core.Modules.Consensus/Deltas/DeltaBuilder.cs
+++ b/src/Catalyst.Core.Modules.Consensus/Deltas/DeltaBuilder.cs
@@ -51,7 +51,7 @@ namespace Catalyst.Core.Modules.Consensus.Deltas
     {
         private const ulong DeltaGasLimit = 8_000_000;
         private const ulong MinTransactionEntryGasLimit = 21_000;
-        
+
         private readonly IDeltaTransactionRetriever _transactionRetriever;
         private readonly IDeterministicRandomFactory _randomFactory;
         private readonly IHashProvider _hashProvider;
@@ -139,8 +139,8 @@ namespace Catalyst.Core.Modules.Consensus.Deltas
             {
                 PreviousDeltaDfsHash = previousDeltaHash.ToArray().ToByteString(),
                 MerkleRoot = candidate.Hash,
-                CoinbaseEntries = {coinbaseEntry},
-                PublicEntries = {includedTransactions.SelectMany(t => t.PublicEntries).Select(x => x)},
+                CoinbaseEntries = { coinbaseEntry },
+                PublicEntries = { includedTransactions.SelectMany(t => t.PublicEntries).Select(x => x) },
                 TimeStamp = Timestamp.FromDateTime(_dateTimeProvider.UtcNow)
             };
 
@@ -151,7 +151,7 @@ namespace Catalyst.Core.Modules.Consensus.Deltas
             return candidate;
         }
 
-        private IEnumerable<byte> GetSaltFromPreviousDelta(Cid previousDeltaHash)
+        private byte[] GetSaltFromPreviousDelta(Cid previousDeltaHash)
         {
             var isaac = _randomFactory.GetDeterministicRandomFromSeed(previousDeltaHash.ToArray());
             return BitConverter.GetBytes(isaac.NextInt());
@@ -164,11 +164,11 @@ namespace Catalyst.Core.Modules.Consensus.Deltas
             public byte[] SaltedAndHashedEntry { get; }
 
             public RawEntryWithSaltedAndHashedEntry(PublicEntry rawEntry,
-                IEnumerable<byte> salt,
+                byte[] salt,
                 IHashProvider hashProvider)
             {
                 RawEntry = rawEntry;
-                SaltedAndHashedEntry = hashProvider.ComputeMultiHash(rawEntry.ToByteArray().Concat(salt)).ToArray();
+                SaltedAndHashedEntry = hashProvider.ComputeMultiHash(rawEntry, salt).ToArray();
             }
         }
 
@@ -177,18 +177,18 @@ namespace Catalyst.Core.Modules.Consensus.Deltas
             private readonly int _multiplier;
 
             private AveragePriceComparer(int multiplier) { _multiplier = multiplier; }
-            
+
             public int Compare(TransactionBroadcast x, TransactionBroadcast y)
             {
                 return _multiplier * Comparer<UInt256?>.Default.Compare(x?.AverageGasPrice, y?.AverageGasPrice);
             }
-            
+
             public static AveragePriceComparer InstanceDesc { get; } = new AveragePriceComparer(-1);
             public static AveragePriceComparer InstanceAsc { get; } = new AveragePriceComparer(1);
         }
-        
+
         private static bool IsTransactionOfAcceptedType(TransactionBroadcast transaction) { return transaction.IsPublicTransaction || transaction.IsContractCall || transaction.IsContractDeployment; }
-        
+
         /// <summary>
         ///     Gets the valid transactions for delta.
         ///     This method can be used to extract the collection of transactions that meet the criteria for validating delta.
@@ -213,7 +213,7 @@ namespace Catalyst.Core.Modules.Consensus.Deltas
 
                 validTransactionsForDelta.Add(currentItem);
             }
-            
+
             validTransactionsForDelta.Sort(AveragePriceComparer.InstanceDesc);
 
             var totalLimit = 0UL;
@@ -228,12 +228,12 @@ namespace Catalyst.Core.Modules.Consensus.Deltas
                     for (var j = i; j < allValidCount; j++)
                     {
                         currentItem = validTransactionsForDelta[j];
-                        rejectedTransactions.Add(currentItem);    
+                        rejectedTransactions.Add(currentItem);
                     }
-                    
+
                     break;
                 }
-                
+
                 var currentItemGasLimit = currentItem.TotalGasLimit;
                 if (remainingLimit < currentItemGasLimit)
                 {
@@ -241,7 +241,7 @@ namespace Catalyst.Core.Modules.Consensus.Deltas
                 }
                 else
                 {
-                    totalLimit += validTransactionsForDelta[i].TotalGasLimit;    
+                    totalLimit += validTransactionsForDelta[i].TotalGasLimit;
                 }
             }
 
@@ -249,10 +249,10 @@ namespace Catalyst.Core.Modules.Consensus.Deltas
             {
                 validTransactionsForDelta.Remove(rejectedTransactions[i]);
             }
-            
+
             _logger.Debug("Delta builder rejected the following transactions {rejectedTransactions}",
                 rejectedTransactions);
-            
+
             return validTransactionsForDelta;
         }
     }

--- a/src/Catalyst.Core.Modules.Consensus/Deltas/DeltaCache.cs
+++ b/src/Catalyst.Core.Modules.Consensus/Deltas/DeltaCache.cs
@@ -60,7 +60,7 @@ namespace Catalyst.Core.Modules.Consensus.Deltas
         {
             var genesisDelta = new Delta {TimeStamp = Timestamp.FromDateTime(DateTime.MinValue.ToUniversalTime())};
 
-            GenesisHash = CidHelper.CreateCid(hashProvider.ComputeMultiHash(genesisDelta.ToByteArray()));
+            GenesisHash = CidHelper.CreateCid(hashProvider.ComputeMultiHash(genesisDelta));
 
             _dfsReader = dfsReader;
             _logger = logger;

--- a/src/Catalyst.Core.Modules.Cryptography.BulletProofs.Tests/UnitTests/CryptoWrapperTests.cs
+++ b/src/Catalyst.Core.Modules.Cryptography.BulletProofs.Tests/UnitTests/CryptoWrapperTests.cs
@@ -126,8 +126,8 @@ namespace Catalyst.Core.Modules.Cryptography.BulletProofs.Tests.UnitTests
         {
             IPrivateKey privateKey = _wrapper.GeneratePrivateKey();
 
-            BaseEntry message1 = new BaseEntry { Nonce = 123 };
-            BaseEntry message2 = new BaseEntry { Nonce = 34534908 };
+            BaseEntry message1 = new BaseEntry {Nonce = 123};
+            BaseEntry message2 = new BaseEntry {Nonce = 34534908};
 
             ISignature expected = _wrapper.Sign(privateKey, message1.ToByteArray(), message2.ToByteArray());
             ISignature actual = _wrapper.Sign(privateKey, message1, message2);

--- a/src/Catalyst.Core.Modules.Cryptography.BulletProofs/Catalyst.Core.Modules.Cryptography.BulletProofs.csproj
+++ b/src/Catalyst.Core.Modules.Cryptography.BulletProofs/Catalyst.Core.Modules.Cryptography.BulletProofs.csproj
@@ -6,6 +6,7 @@
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>Catalyst.Core.Modules.Cryptography.BulletProofs.snk</AssemblyOriginatorKeyFile>
         <PublicSign>true</PublicSign>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
     <Import Project="../Common.Packable.props" />
     <Import Project="../Common.Projects.props" />

--- a/src/Catalyst.Core.Modules.Cryptography.BulletProofs/FfiWrapper.cs
+++ b/src/Catalyst.Core.Modules.Cryptography.BulletProofs/FfiWrapper.cs
@@ -40,14 +40,24 @@ namespace Catalyst.Core.Modules.Cryptography.BulletProofs
 
         public ISignature Sign(IPrivateKey privateKey, byte[] messageBytes, byte[] contextBytes)
         {
-            return NativeBinding.StdSign(privateKey.Bytes, messageBytes, contextBytes);           
+            return NativeBinding.StdSign(privateKey.Bytes, messageBytes, messageBytes.Length, contextBytes, contextBytes.Length);           
+        }
+        
+        public ISignature Sign(IPrivateKey privateKey, byte[] messageBytes, int messageLength, byte[] contextBytes, int contextLength)
+        {
+            return NativeBinding.StdSign(privateKey.Bytes, messageBytes, messageLength, contextBytes, contextLength);           
         }
 
         public bool Verify(ISignature signature, byte[] message, byte[] context)
         {
-            return NativeBinding.StdVerify(signature.SignatureBytes, signature.PublicKeyBytes, message, context);
+            return NativeBinding.StdVerify(signature.SignatureBytes, signature.PublicKeyBytes, message, message.Length, context, context.Length);
         }
-        
+
+        public bool Verify(ISignature signature, byte[] message, int messageLength, byte[] context, int contextLength)
+        {
+            return NativeBinding.StdVerify(signature.SignatureBytes, signature.PublicKeyBytes, message, messageLength, context, contextLength);
+        }
+
         public IPrivateKey GeneratePrivateKey()
         {           
             return NativeBinding.GeneratePrivateKey();

--- a/src/Catalyst.Core.Modules.Cryptography.BulletProofs/FfiWrapper.cs
+++ b/src/Catalyst.Core.Modules.Cryptography.BulletProofs/FfiWrapper.cs
@@ -21,6 +21,7 @@
 
 #endregion
 
+using System;
 using System.Collections.Generic;
 using Catalyst.Abstractions.Cryptography;
 using Catalyst.Abstractions.Types;
@@ -38,24 +39,14 @@ namespace Catalyst.Core.Modules.Cryptography.BulletProofs
 
         public int SignatureContextMaxLength => NativeBinding.SignatureContextMaxLength;
 
-        public ISignature Sign(IPrivateKey privateKey, byte[] messageBytes, byte[] contextBytes)
+        public ISignature Sign(IPrivateKey privateKey, ReadOnlySpan<byte> message, ReadOnlySpan<byte> context)
         {
-            return NativeBinding.StdSign(privateKey.Bytes, messageBytes, messageBytes.Length, contextBytes, contextBytes.Length);           
-        }
-        
-        public ISignature Sign(IPrivateKey privateKey, byte[] messageBytes, int messageLength, byte[] contextBytes, int contextLength)
-        {
-            return NativeBinding.StdSign(privateKey.Bytes, messageBytes, messageLength, contextBytes, contextLength);           
+            return NativeBinding.StdSign(privateKey.Bytes, message, context);           
         }
 
-        public bool Verify(ISignature signature, byte[] message, byte[] context)
+        public bool Verify(ISignature signature, ReadOnlySpan<byte> message, ReadOnlySpan<byte> context)
         {
-            return NativeBinding.StdVerify(signature.SignatureBytes, signature.PublicKeyBytes, message, message.Length, context, context.Length);
-        }
-
-        public bool Verify(ISignature signature, byte[] message, int messageLength, byte[] context, int contextLength)
-        {
-            return NativeBinding.StdVerify(signature.SignatureBytes, signature.PublicKeyBytes, message, messageLength, context, contextLength);
+            return NativeBinding.StdVerify(signature.SignatureBytes, signature.PublicKeyBytes, message, context);
         }
 
         public IPrivateKey GeneratePrivateKey()

--- a/src/Catalyst.Core.Modules.Cryptography.BulletProofs/NativeBinding.cs
+++ b/src/Catalyst.Core.Modules.Cryptography.BulletProofs/NativeBinding.cs
@@ -52,7 +52,7 @@ namespace Catalyst.Core.Modules.Cryptography.BulletProofs
         [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
         private static extern int std_sign(byte[] signature, byte[] publicKey, byte[] privateKey, byte[] message, int messageLength, byte[] context, int contextLength);
 
-        internal static ISignature StdSign(byte[] privateKey, byte[] message, byte[] context)
+        internal static ISignature StdSign(byte[] privateKey, byte[] message, int messageLength, byte[] context, int contextLength)
         {
             if (privateKey.Length != PrivateKeyLength)
             {
@@ -62,8 +62,8 @@ namespace Catalyst.Core.Modules.Cryptography.BulletProofs
             var signature = new byte[SignatureLength];
             var publicKey = new byte[PublicKeyLength];
 
-            var error_code = std_sign(signature, publicKey, privateKey, message, message.Length, context, context.Length);
-            
+            var error_code = std_sign(signature, publicKey, privateKey, message, messageLength, context, contextLength);
+
             if (ErrorCode.TryParse<ErrorCode>(error_code.ToString(), out var errorCode) && errorCode != ErrorCode.NoError)
             {
                 Error.ThrowErrorFromErrorCode(errorCode);
@@ -71,11 +71,11 @@ namespace Catalyst.Core.Modules.Cryptography.BulletProofs
 
             return new Signature(signature, publicKey);
         }
-        
+
         [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
         private static extern int std_verify(byte[] signature, byte[] publicKey, byte[] message, int messageLength, byte[] context, int contextLength);
 
-        internal static bool StdVerify(byte[] signature, byte[] publicKey, byte[] message, byte[] context)
+        internal static bool StdVerify(byte[] signature, byte[] publicKey, byte[] message, int messageLength, byte[] context, int contextLength)
         {
             if (signature.Length != SignatureLength)
             {
@@ -87,7 +87,7 @@ namespace Catalyst.Core.Modules.Cryptography.BulletProofs
                 Error.ThrowArgumentExceptionPublicKeyLength(PublicKeyLength);
             }
 
-            var error_code = std_verify(signature, publicKey, message, message.Length, context, context.Length);
+            var error_code = std_verify(signature, publicKey, message, messageLength, context, contextLength);
 
             ErrorCode.TryParse<ErrorCode>(error_code.ToString(), out var errorCode);
 
@@ -110,9 +110,9 @@ namespace Catalyst.Core.Modules.Cryptography.BulletProofs
         internal static void ValidatePublicKeyOrThrow(byte[] publicKey)
         {
             if (publicKey.Length != PublicKeyLength)
-            { 
+            {
                 Error.ThrowArgumentExceptionPublicKeyLength(PublicKeyLength);
-            } 
+            }
 
             var error_code = validate_public_key(publicKey);
 
@@ -134,7 +134,7 @@ namespace Catalyst.Core.Modules.Cryptography.BulletProofs
 
             var publicKeyBytes = new byte[PublicKeyLength];
             publickey_from_private(publicKeyBytes, privateKey);
-            
+
             return new PublicKey(publicKeyBytes);
         }
 
@@ -158,7 +158,7 @@ namespace Catalyst.Core.Modules.Cryptography.BulletProofs
             {
                 if (_privateKeyLength == 0)
                 {
-                    _privateKeyLength = get_private_key_length(); 
+                    _privateKeyLength = get_private_key_length();
                 }
 
                 return _privateKeyLength;
@@ -173,7 +173,7 @@ namespace Catalyst.Core.Modules.Cryptography.BulletProofs
             {
                 if (_publicKeyLength == 0)
                 {
-                    _publicKeyLength = get_public_key_length(); 
+                    _publicKeyLength = get_public_key_length();
                 }
 
                 return _publicKeyLength;
@@ -188,7 +188,7 @@ namespace Catalyst.Core.Modules.Cryptography.BulletProofs
             {
                 if (_signatureLength == 0)
                 {
-                    _signatureLength = get_signature_length(); 
+                    _signatureLength = get_signature_length();
                 }
 
                 return _signatureLength;
@@ -203,7 +203,7 @@ namespace Catalyst.Core.Modules.Cryptography.BulletProofs
             {
                 if (_signatureContextMaxLength == 0)
                 {
-                    _signatureContextMaxLength = get_max_context_length(); 
+                    _signatureContextMaxLength = get_max_context_length();
                 }
 
                 return _signatureContextMaxLength;

--- a/src/Catalyst.Core.Modules.Hashing.Tests/UnitTests/HashingTests.cs
+++ b/src/Catalyst.Core.Modules.Hashing.Tests/UnitTests/HashingTests.cs
@@ -22,10 +22,13 @@
 #endregion
 
 using System;
+using System.Linq;
 using Autofac;
 using Catalyst.Abstractions.Hashing;
 using Catalyst.Core.Modules.Hashing;
+using Catalyst.Protocol.Transaction;
 using FluentAssertions;
+using Google.Protobuf;
 using TheDotNetLeague.MultiFormats.MultiHash;
 using Xunit;
 
@@ -60,6 +63,32 @@ namespace Catalyst.Core.Modules.Consensus.Tests.UnitTests
             var data = BitConverter.GetBytes(0xDEADBEEF);
             var multiHash = hashProvider.ComputeMultiHash(data);
             multiHash.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void Hashes_messages()
+        {
+            var hashProvider = _container.Resolve<IHashProvider>();
+            var entry = new BaseEntry();
+
+            var arrayHash = hashProvider.ComputeMultiHash(entry.ToByteArray());
+            var messageHash = hashProvider.ComputeMultiHash(entry);
+
+            arrayHash.ToArray().Should().BeEquivalentTo(messageHash.ToArray());
+        }
+
+        [Fact]
+        public void Hashes_messages_with_suffix()
+        {
+            var hashProvider = _container.Resolve<IHashProvider>();
+            var entry = new BaseEntry();
+
+            var suffix = new byte[1];
+
+            var arrayHash = hashProvider.ComputeMultiHash(entry.ToByteArray().Concat(suffix).ToArray());
+            var messageHash = hashProvider.ComputeMultiHash(entry, suffix);
+
+            arrayHash.ToArray().Should().BeEquivalentTo(messageHash.ToArray());
         }
     }
 }

--- a/src/Catalyst.Core.Modules.Hashing/HashProvider.cs
+++ b/src/Catalyst.Core.Modules.Hashing/HashProvider.cs
@@ -27,6 +27,7 @@ using System.Linq;
 using System.Text;
 using Catalyst.Abstractions.Hashing;
 using Google.Protobuf;
+using Org.BouncyCastle.Crypto.Tls;
 using TheDotNetLeague.MultiFormats.MultiHash;
 
 namespace Catalyst.Core.Modules.Hashing
@@ -41,28 +42,28 @@ namespace Catalyst.Core.Modules.Hashing
         /// <param name="buffer"></param>
         /// <returns></returns>
         public static MultiHash Parse(string buffer) { return new MultiHash(buffer); }
-        
+
         /// <summary>
         ///     Parse a byte array representation of a multihash
         /// </summary>
         /// <param name="buffer"></param>
         /// <returns></returns>
         public static MultiHash Parse(byte[] buffer) { return new MultiHash(buffer); }
-        
+
         /// <summary>
         ///     Parse a memory stream representation of a multihash
         /// </summary>
         /// <param name="stream"></param>
         /// <returns></returns>
         public static MultiHash Parse(MemoryStream stream) { return new MultiHash(stream); }
-        
+
         /// <summary>
         ///     Parse a protobuff coded input stream representation of a multihash
         /// </summary>
         /// <param name="stream"></param>
         /// <returns></returns>
         public static MultiHash Parse(CodedInputStream stream) { return new MultiHash(stream); }
-        
+
         public HashProvider(HashingAlgorithm hashingAlgorithm) { HashingAlgorithm = hashingAlgorithm; }
 
         public MultiHash Cast(byte[] data) { return CastIfHashIsValid(data); }
@@ -87,24 +88,20 @@ namespace Catalyst.Core.Modules.Hashing
             }
         }
 
-        public MultiHash ComputeUtf8MultiHash(string data)
-        {
-            return ComputeMultiHash(Encoding.UTF8.GetBytes(data));
-        }
+        public MultiHash ComputeUtf8MultiHash(string data) { return ComputeMultiHash(Encoding.UTF8.GetBytes(data)); }
 
-        public MultiHash ComputeMultiHash(IEnumerable<byte> data)
-        {
-            return ComputeMultiHash(data.ToArray());
-        }
+        public MultiHash ComputeMultiHash(IEnumerable<byte> data) { return ComputeMultiHash(data.ToArray()); }
 
-        public MultiHash ComputeMultiHash(byte[] data)
-        {
-            return MultiHash.ComputeHash(data, HashingAlgorithm.Name);
-        }
+        public MultiHash ComputeMultiHash(byte[] data) { return MultiHash.ComputeHash(data, HashingAlgorithm.Name); }
 
-        public MultiHash ComputeMultiHash(Stream data)
+        public MultiHash ComputeMultiHash(Stream data) { return MultiHash.ComputeHash(data, HashingAlgorithm.Name); }
+
+        public MultiHash ComputeMultiHash(byte[] data, int offset, int count)
         {
-            return MultiHash.ComputeHash(data, HashingAlgorithm.Name);
+            using (var algorithm = HashingAlgorithm.Hasher())
+            {
+                return new MultiHash(HashingAlgorithm.Name, algorithm.ComputeHash(data, offset, count));
+            }
         }
     }
 }

--- a/src/Catalyst.Core.Modules.KeySigner/KeySigner.cs
+++ b/src/Catalyst.Core.Modules.KeySigner/KeySigner.cs
@@ -89,28 +89,16 @@ namespace Catalyst.Core.Modules.KeySigner
             return privateKey;
         }
 
-        public ISignature Sign(byte[] data, SigningContext signingContext)
+        public ISignature Sign(ReadOnlySpan<byte> data, SigningContext signingContext)
         {
             var privateKey = GetPrivateKey(KeyRegistryTypes.DefaultKey);
             return _cryptoContext.Sign(privateKey, data, signingContext.ToByteArray());
         }
 
-        public ISignature Sign(IMessage data, SigningContext signingContext)
-        {
-            var privateKey = GetPrivateKey(KeyRegistryTypes.DefaultKey);
-            return _cryptoContext.Sign(privateKey, data, signingContext);
-        }
-
         /// <inheritdoc/>
-        public bool Verify(ISignature signature, byte[] message, SigningContext signingContext)
+        public bool Verify(ISignature signature, ReadOnlySpan<byte> data, SigningContext signingContext)
         {
-            return _cryptoContext.Verify(signature, message, signingContext.ToByteArray());
-        }
-
-        /// <inheritdoc/>
-        public bool Verify(ISignature signature, IMessage message, SigningContext signingContext)
-        {
-            return _cryptoContext.Verify(signature, message, signingContext);
+            return _cryptoContext.Verify(signature, data, signingContext.ToByteArray());
         }
 
         public void ExportKey()

--- a/src/Catalyst.Core.Modules.KeySigner/KeySigner.cs
+++ b/src/Catalyst.Core.Modules.KeySigner/KeySigner.cs
@@ -78,7 +78,7 @@ namespace Catalyst.Core.Modules.KeySigner
         /// <inheritdoc/>
         ICryptoContext IKeySigner.CryptoContext => _cryptoContext;
 
-        private ISignature Sign(byte[] data, SigningContext signingContext, KeyRegistryTypes keyIdentifier)
+        IPrivateKey GetPrivateKey(KeyRegistryTypes keyIdentifier)
         {
             var privateKey = _keyRegistry.GetItemFromRegistry(keyIdentifier);
             if (privateKey == null && !TryPopulateRegistryFromKeyStore(keyIdentifier, out privateKey))
@@ -86,23 +86,31 @@ namespace Catalyst.Core.Modules.KeySigner
                 throw new SignatureException("The signature cannot be created because the key does not exist");
             }
 
-            return Sign(data, signingContext, privateKey);
+            return privateKey;
         }
 
         public ISignature Sign(byte[] data, SigningContext signingContext)
         {
-            return Sign(data, signingContext, KeyRegistryTypes.DefaultKey);
+            var privateKey = GetPrivateKey(KeyRegistryTypes.DefaultKey);
+            return _cryptoContext.Sign(privateKey, data, signingContext.ToByteArray());
         }
 
-        private ISignature Sign(byte[] data, SigningContext signingContext, IPrivateKey privateKey)
+        public ISignature Sign(IMessage data, SigningContext signingContext)
         {
-            return _cryptoContext.Sign(privateKey, data, signingContext.ToByteArray());
+            var privateKey = GetPrivateKey(KeyRegistryTypes.DefaultKey);
+            return _cryptoContext.Sign(privateKey, data, signingContext);
         }
 
         /// <inheritdoc/>
         public bool Verify(ISignature signature, byte[] message, SigningContext signingContext)
         {
             return _cryptoContext.Verify(signature, message, signingContext.ToByteArray());
+        }
+
+        /// <inheritdoc/>
+        public bool Verify(ISignature signature, IMessage message, SigningContext signingContext)
+        {
+            return _cryptoContext.Verify(signature, message, signingContext);
         }
 
         public void ExportKey()

--- a/src/Catalyst.Core.Modules.KeySigner/KeySigner.cs
+++ b/src/Catalyst.Core.Modules.KeySigner/KeySigner.cs
@@ -42,7 +42,6 @@ namespace Catalyst.Core.Modules.KeySigner
         private readonly ICryptoContext _cryptoContext;
         private readonly IKeyRegistry _keyRegistry;
         private readonly KeyRegistryTypes _defaultKey = KeyRegistryTypes.DefaultKey;
-        static readonly ArrayPool<byte> Pool = ArrayPool<byte>.Shared;
 
         /// <summary>Initializes a new instance of the <see cref="KeySigner"/> class.</summary>
         /// <param name="keyStore">The key store.</param>
@@ -104,7 +103,7 @@ namespace Catalyst.Core.Modules.KeySigner
         /// <inheritdoc/>
         public bool Verify(ISignature signature, ReadOnlySpan<byte> data, SigningContext signingContext)
         {
-            var pooled = signingContext.SerializeToPooledBytes();
+            using var pooled = signingContext.SerializeToPooledBytes();
 
             return _cryptoContext.Verify(signature, data, pooled.Span);
         }

--- a/src/Catalyst.Core.Modules.KeySigner/KeySigner.cs
+++ b/src/Catalyst.Core.Modules.KeySigner/KeySigner.cs
@@ -96,23 +96,17 @@ namespace Catalyst.Core.Modules.KeySigner
         {
             var privateKey = GetPrivateKey(KeyRegistryTypes.DefaultKey);
 
-            var span = Pool.Serialize(signingContext, out var array);
+            using var pooled = signingContext.SerializeToPooledBytes();
 
-            var result = _cryptoContext.Sign(privateKey, data, span);
-            
-            Pool.Return(array);
-            return result;
+            return _cryptoContext.Sign(privateKey, data, pooled.Span);
         }
 
         /// <inheritdoc/>
         public bool Verify(ISignature signature, ReadOnlySpan<byte> data, SigningContext signingContext)
         {
-            var span = Pool.Serialize(signingContext, out var array);
-            
-            var result = _cryptoContext.Verify(signature, data, span);
-            
-            Pool.Return(array);
-            return result;
+            var pooled = signingContext.SerializeToPooledBytes();
+
+            return _cryptoContext.Verify(signature, data, pooled.Span);
         }
 
         public void ExportKey()

--- a/src/Catalyst.Core.Modules.Rpc.Server/IO/Observers/VerifyMessageRequestObserver.cs
+++ b/src/Catalyst.Core.Modules.Rpc.Server/IO/Observers/VerifyMessageRequestObserver.cs
@@ -67,7 +67,7 @@ namespace Catalyst.Core.Modules.Rpc.Server.IO.Observers
             Guard.Argument(senderPeerId, nameof(senderPeerId)).NotNull();
             Logger.Debug("received message of type VerifyMessageRequest");
 
-            var decodedMessage = verifyMessageRequest.Message.ToByteArray();
+            var decodedMessage = verifyMessageRequest.Message;
             var decodedPublicKey = verifyMessageRequest.PublicKey.ToByteArray();
             var decodedSignature = verifyMessageRequest.Signature.ToByteArray();
             var signatureContext = verifyMessageRequest.SigningContext;
@@ -95,7 +95,7 @@ namespace Catalyst.Core.Modules.Rpc.Server.IO.Observers
                 return ReturnResponse(false);
             }
 
-            var result = _keySigner.Verify(signature, decodedMessage, signatureContext);
+            var result = _keySigner.Verify(signature, decodedMessage.Span, signatureContext);
 
             Logger.Debug("message content is {0}", verifyMessageRequest.Message);
 

--- a/src/Catalyst.Modules.POA.Consensus/Deltas/PoaDeltaProducersProvider.cs
+++ b/src/Catalyst.Modules.POA.Consensus/Deltas/PoaDeltaProducersProvider.cs
@@ -88,10 +88,11 @@ namespace Catalyst.Modules.POA.Consensus.Deltas
 
             var allPeers = PeerRepository.GetAll().Concat(new[] {_selfAsPeer});
 
+            var previous = previousDeltaHash.ToArray();
+
             var peerIdsInPriorityOrder = allPeers.Select(p =>
                 {
-                    var array = p.PeerId.ToByteArray().Concat(previousDeltaHash.ToArray()).ToArray();
-                    var ranking = _hashProvider.ComputeMultiHash(array).ToArray();
+                    var ranking = _hashProvider.ComputeMultiHash(p.PeerId, previous).ToArray();
                     return new
                     {
                         p.PeerId,

--- a/src/Catalyst.sln
+++ b/src/Catalyst.sln
@@ -167,6 +167,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Catalyst.Documentation", ".
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Catalyst.Tools.KeyGenerator", "Catalyst.Tools.KeyGenerator\Catalyst.Tools.KeyGenerator.csproj", "{2FEC7DC6-A6C1-4692-B5C3-1415B86DE761}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Catalyst.Benchmark", "Catalyst.Benchmark\Catalyst.Benchmark.csproj", "{EC7C0AAF-8EC0-491C-B98E-0EC9EBBA21CE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -373,6 +375,10 @@ Global
 		{2FEC7DC6-A6C1-4692-B5C3-1415B86DE761}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2FEC7DC6-A6C1-4692-B5C3-1415B86DE761}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2FEC7DC6-A6C1-4692-B5C3-1415B86DE761}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC7C0AAF-8EC0-491C-B98E-0EC9EBBA21CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC7C0AAF-8EC0-491C-B98E-0EC9EBBA21CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC7C0AAF-8EC0-491C-B98E-0EC9EBBA21CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC7C0AAF-8EC0-491C-B98E-0EC9EBBA21CE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Common.Projects.props
+++ b/src/Common.Projects.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
     <PropertyGroup>
         <Company>catalystnet.org</Company>
         <Copyright>Copyright © 2019 Catalyst Network</Copyright>
@@ -7,7 +7,7 @@
         <RepositoryUrl>https://github.com/Catalyst-network/Catalyst.Node</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <RuntimeFrameworkVersion>3.0.0</RuntimeFrameworkVersion>
-        <LangVersion>7.3</LangVersion>
+        <LangVersion>8.0</LangVersion>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
         <Deterministic>true</Deterministic>
         <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
### New Pull Request Submissions:

1. [x] Have you followed the guidelines in our [Contributing document](https://github.com/atlascity/Community/tree/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
3. [x] I have added tests to cover my changes.
4. [x] All new and existing tests passed.
5. [x] Have you lint your code locally prior to submission?
6. [x] Does your code follows the code style of this project?
7. [ ] Does your change require a change to the documentation.
    - [ ] I have updated the documentation accordingly.
9. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
10. [ ] Have you inserted a keyword and link to the issues the PR closes in its descriptions (ex `closes #1`) ?
11. [x] Is you branch up to date, have you integrated all the latest changes from develop and resolved conflicts ?

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR changes methods of `IHashProvider` and `ICryptoContext` that enable them to hash / sigh / verify messages without allocating memory via `.ToByteArray()`. 

Additionally, for the hasher, one method is added that enables a concatenation of a message byte payload with a suffix. This method can be used to greatly improved (benchmark added) an execution of `DeltaBuilder`.

* **What is the current behavior?** (You can also link to an open issue here)

Currently, in several places there are calls `.ToByteArray`, to pass a proto message as `byte[]` to a method. 

* **What is the new behavior (if this is a feature change)?**

This PR changes several cases, to use `ReadOnlySpan<byte>` that allows:

1. using a message serialized an array from to `ArrayPool<byte>.Shared`
1. using `ByteString.Span` without cloning its content
1. using stack-allocated span whenever possible (currently, not used)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

The public API that is changed is following:

1. `IKeySigner`
1. `IHashProvider` 
1. `ICryptoContext`

The hash provider has not Span based overloads, as underlying Blake implementation based on Bouncy Castle, does not currently use currently [TryComputeHash](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm.trycomputehash).

* **Other information**:

There are a few more methods that could be possibly spanified in similar manner, like: `ICryptoContext.GetSignatureFromBytes(byte[] signatureBytes, byte[] publicKeyBytes)`

Some benchmarks that were added, that might be useful for future improvement. In the second case, the embedded serialization

### Benchmark: calculating a hash for a single item + salt in DeltaBuilder

|          Method |       Mean |    Error |   StdDev |  Gen 0 |  Allocated |
|---------------- |-----------:|---------:|---------:|-------:|--------:|
|   Concat_manual | 1,798.5 ns | 35.33 ns | 55.00 ns | 0.2956 |   928 B |
| Concat_embedded |   309.4 ns |  7.65 ns | 21.72 ns | 0.0587 |      184 B |

### Benchmark: Sign/Verify chain 

|                                 Method |     Mean |    Error |   StdDev |   Median | Allocated |
|--------------------------------------- |---------:|---------:|---------:|---------:|----------:|
|            SignVerify_with_ToByteArray | 704.2 ns | 14.01 ns | 37.87 ns | 685.9 ns |     624 B |
| SignVerify_with_embedded_serialization | 744.2 ns | 14.61 ns | 28.49 ns | 743.1 ns |      96 B |


