### PR TITLE
Better substitutes for spanified interfaces

### DIFF
--- a/src/Catalyst.Core.Lib.Tests/Catalyst.Core.Lib.Tests.csproj.DotSettings
+++ b/src/Catalyst.Core.Lib.Tests/Catalyst.Core.Lib.Tests.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=fakes/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Catalyst.Core.Lib.Tests/Fakes/FakeKeySigner.cs
+++ b/src/Catalyst.Core.Lib.Tests/Fakes/FakeKeySigner.cs
@@ -26,12 +26,11 @@ using Catalyst.Abstractions.Cryptography;
 using Catalyst.Abstractions.KeySigner;
 using Catalyst.Abstractions.Keystore;
 using Catalyst.Protocol.Cryptography;
-using NSubstitute;
 
 namespace Catalyst.Core.Lib.Tests 
 {
     /// <summary>
-    /// A fake <see cref="IKeySigner"/> that enables to use NSubstite for faking instances of it.
+    /// A fake <see cref="IKeySigner"/> that enables to use NSubstitute for faking instances of it.
     /// </summary>
     public abstract class FakeKeySigner : IKeySigner
     {
@@ -39,11 +38,11 @@ namespace Catalyst.Core.Lib.Tests
         public abstract ICryptoContext CryptoContext { get; }
         
         // The reimplemented span-based method
-        public ISignature Sign(ReadOnlySpan<byte> data, SigningContext signingContext) => Sign(data.ToArray(), signingContext);
+        ISignature IKeySigner.Sign(ReadOnlySpan<byte> data, SigningContext signingContext) => Sign(data.ToArray(), signingContext);
         public abstract ISignature Sign(byte[] data, SigningContext signingContext);
         
         // The reimplemented span-based method
-        public bool Verify(ISignature signature, ReadOnlySpan<byte> data, SigningContext signingContext) => Verify(signature, data.ToArray(), signingContext);
+        bool IKeySigner.Verify(ISignature signature, ReadOnlySpan<byte> data, SigningContext signingContext) => Verify(signature, data.ToArray(), signingContext);
         public abstract bool Verify(ISignature signature, byte[] data, SigningContext signingContext);
     }
 }

--- a/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/IO/Transport/Channels/PeerClientChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/IO/Transport/Channels/PeerClientChannelFactoryTests.cs
@@ -32,7 +32,6 @@ using Catalyst.Core.Lib.Extensions;
 using Catalyst.Core.Lib.IO.Handlers;
 using Catalyst.Core.Lib.IO.Messaging.Correlation;
 using Catalyst.Core.Lib.IO.Messaging.Dto;
-using Catalyst.Core.Lib.Tests.Fakes;
 using Catalyst.Protocol.Wire;
 using Catalyst.Protocol.IPPN;
 using Catalyst.Protocol.Network;
@@ -41,7 +40,6 @@ using Catalyst.TestUtils;
 using DotNetty.Transport.Channels.Embedded;
 using DotNetty.Transport.Channels.Sockets;
 using FluentAssertions;
-using Google.Protobuf;
 using Microsoft.Reactive.Testing;
 using NSubstitute;
 using Serilog;
@@ -56,16 +54,17 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
         private readonly EmbeddedChannel _serverChannel;
         private readonly EmbeddedChannel _clientChannel;
         private readonly IPeerMessageCorrelationManager _clientCorrelationManager;
-        private readonly FakeKeySigner _clientKeySigner;
+        private readonly IKeySigner _clientKeySigner;
         private readonly IPeerIdValidator _peerIdValidator;
-        private readonly FakeKeySigner _serverKeySigner;
+        private readonly IKeySigner _serverKeySigner;
         private readonly IPeerMessageCorrelationManager _serverCorrelationManager;
+        private readonly ISignature _signature;
 
         public PeerClientChannelFactoryTests()
         {
             _testScheduler = new TestScheduler();
             _serverCorrelationManager = Substitute.For<IPeerMessageCorrelationManager>();
-            _serverKeySigner = FakeKeySigner.SignOnly();
+            _serverKeySigner = Substitute.For<FakeKeySigner>();
             _serverKeySigner.CryptoContext.SignatureLength.Returns(64);
             var broadcastManager = Substitute.For<IBroadcastManager>();
 
@@ -82,8 +81,10 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
                 peerSettings,
                 _testScheduler);
 
+            _signature = Substitute.For<ISignature>();
+
             _clientCorrelationManager = Substitute.For<IPeerMessageCorrelationManager>();
-            _clientKeySigner = FakeKeySigner.VerifyOnly();
+            _clientKeySigner = Substitute.For<FakeKeySigner>();
             _clientKeySigner.CryptoContext.SignatureLength.Returns(64);
 
             _clientFactory = new UnitTests.P2P.IO.Transport.Channels.PeerClientChannelFactoryTests.TestPeerClientChannelFactory(
@@ -109,6 +110,8 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
             var sender = PeerIdHelper.GetPeerId("sender");
             _peerIdValidator.ValidatePeerIdFormat(Arg.Any<PeerId>()).Returns(true);
 
+            _serverKeySigner.Sign(Arg.Any<byte[]>(), default).ReturnsForAnyArgs(_signature);
+            
             var correlationId = CorrelationId.GenerateCorrelationId();
 
             var protocolMessage = new PingRequest().ToProtocolMessage(sender, correlationId);
@@ -121,8 +124,15 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
 
             _serverCorrelationManager.ReceivedWithAnyArgs(1)
                .AddPendingRequest(Arg.Any<CorrelatableMessage<ProtocolMessage>>());
-
-            _serverKeySigner.SignCount.Should().Be(1);
+            
+            _serverKeySigner.ReceivedWithAnyArgs(1).Sign(Arg.Any<byte[]>(), default);
+            
+            _clientKeySigner.Verify(
+                    Arg.Any<ISignature>(),
+                    Arg.Any<byte[]>(), 
+                    default
+                )
+               .ReturnsForAnyArgs(true);
             
             var observer = new ProtocolMessageObserver(0, Substitute.For<ILogger>());
 
@@ -134,7 +144,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
                 _clientChannel.ReadInbound<ProtocolMessage>();
                 _clientCorrelationManager.DidNotReceiveWithAnyArgs().TryMatchResponse(Arg.Any<ProtocolMessage>());
 
-                _clientKeySigner.VerifyCount.Should().Be(1);
+                _clientKeySigner.ReceivedWithAnyArgs(1).Verify(null, null, null);
 
                 _testScheduler.Start();
 

--- a/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/IO/Transport/Channels/PeerClientChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/IO/Transport/Channels/PeerClientChannelFactoryTests.cs
@@ -54,9 +54,9 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
         private readonly EmbeddedChannel _serverChannel;
         private readonly EmbeddedChannel _clientChannel;
         private readonly IPeerMessageCorrelationManager _clientCorrelationManager;
-        private readonly IKeySigner _clientKeySigner;
+        private readonly FakeKeySigner _clientKeySigner;
         private readonly IPeerIdValidator _peerIdValidator;
-        private readonly IKeySigner _serverKeySigner;
+        private readonly FakeKeySigner _serverKeySigner;
         private readonly IPeerMessageCorrelationManager _serverCorrelationManager;
         private readonly ISignature _signature;
 

--- a/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/IO/Transport/Channels/PeerServerChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/IO/Transport/Channels/PeerServerChannelFactoryTests.cs
@@ -57,16 +57,16 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
         private readonly EmbeddedChannel _serverChannel;
         private readonly EmbeddedChannel _clientChannel;
         private readonly IPeerMessageCorrelationManager _clientCorrelationManager;
-        private readonly IKeySigner _clientKeySigner;
+        private readonly FakeKeySigner _clientKeySigner;
         private readonly IPeerIdValidator _peerIdValidator;
-        private readonly IKeySigner _serverKeySigner;
+        private readonly FakeKeySigner _serverKeySigner;
         private readonly IPeerMessageCorrelationManager _serverCorrelationManager;
 
         public PeerServerChannelFactoryTests()
         {
             _testScheduler = new TestScheduler();
             _serverCorrelationManager = Substitute.For<IPeerMessageCorrelationManager>();
-            _serverKeySigner = Substitute.For<IKeySigner>();
+            _serverKeySigner = Substitute.For<FakeKeySigner>();
             var broadcastManager = Substitute.For<IBroadcastManager>();
 
             _peerIdValidator = Substitute.For<IPeerIdValidator>();

--- a/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/IO/Transport/Channels/PeerServerChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/IO/Transport/Channels/PeerServerChannelFactoryTests.cs
@@ -23,6 +23,8 @@
 
 using System.Linq;
 using System.Threading.Tasks;
+using Catalyst.Abstractions.Cryptography;
+using Catalyst.Abstractions.KeySigner;
 using Catalyst.Abstractions.P2P;
 using Catalyst.Abstractions.P2P.IO.Messaging.Broadcast;
 using Catalyst.Abstractions.P2P.IO.Messaging.Correlation;
@@ -30,7 +32,6 @@ using Catalyst.Core.Lib.Extensions;
 using Catalyst.Core.Lib.IO.Handlers;
 using Catalyst.Core.Lib.IO.Messaging.Correlation;
 using Catalyst.Core.Lib.IO.Messaging.Dto;
-using Catalyst.Core.Lib.Tests.Fakes;
 using Catalyst.Protocol.Wire;
 using Catalyst.Protocol.IPPN;
 using Catalyst.Protocol.Network;
@@ -39,7 +40,6 @@ using Catalyst.TestUtils;
 using DotNetty.Transport.Channels.Embedded;
 using DotNetty.Transport.Channels.Sockets;
 using FluentAssertions;
-using Google.Protobuf;
 using Microsoft.Reactive.Testing;
 using NSubstitute;
 using Serilog;
@@ -57,16 +57,16 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
         private readonly EmbeddedChannel _serverChannel;
         private readonly EmbeddedChannel _clientChannel;
         private readonly IPeerMessageCorrelationManager _clientCorrelationManager;
-        private readonly FakeKeySigner _clientKeySigner;
+        private readonly IKeySigner _clientKeySigner;
         private readonly IPeerIdValidator _peerIdValidator;
-        private readonly FakeKeySigner _serverKeySigner;
+        private readonly IKeySigner _serverKeySigner;
         private readonly IPeerMessageCorrelationManager _serverCorrelationManager;
 
         public PeerServerChannelFactoryTests()
         {
             _testScheduler = new TestScheduler();
             _serverCorrelationManager = Substitute.For<IPeerMessageCorrelationManager>();
-            _serverKeySigner = FakeKeySigner.SignOnly();
+            _serverKeySigner = Substitute.For<IKeySigner>();
             var broadcastManager = Substitute.For<IBroadcastManager>();
 
             _peerIdValidator = Substitute.For<IPeerIdValidator>();
@@ -84,7 +84,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
                     _testScheduler);
 
             _clientCorrelationManager = Substitute.For<IPeerMessageCorrelationManager>();
-            _clientKeySigner = FakeKeySigner.VerifyOnly();
+            _clientKeySigner = Substitute.For<FakeKeySigner>();
 
             _clientFactory =
                 new UnitTests.P2P.IO.Transport.Channels.PeerClientChannelFactoryTests.TestPeerClientChannelFactory(
@@ -109,8 +109,10 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
             var recipient = PeerIdHelper.GetPeerId("recipient");
             var sender = PeerIdHelper.GetPeerId("sender");
 
+            var signature = Substitute.For<ISignature>();
             _peerIdValidator.ValidatePeerIdFormat(Arg.Any<PeerId>()).Returns(true);
             _serverKeySigner.CryptoContext.SignatureLength.Returns(64);
+            _serverKeySigner.Sign(Arg.Any<byte[]>(), default).ReturnsForAnyArgs(signature);
 
             var correlationId = CorrelationId.GenerateCorrelationId();
 
@@ -128,7 +130,13 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
             _serverCorrelationManager.DidNotReceiveWithAnyArgs()
                .AddPendingRequest(Arg.Any<CorrelatableMessage<ProtocolMessage>>());
 
-            _serverKeySigner.SignCount.Should().Be(1);
+            _serverKeySigner.ReceivedWithAnyArgs(1).Sign(Arg.Any<byte[]>(), default);
+
+            _clientKeySigner.Verify(
+                    Arg.Any<ISignature>(),
+                    Arg.Any<byte[]>(),
+                    default)
+               .ReturnsForAnyArgs(true);
 
             var observer = new ProtocolMessageObserver(0, Substitute.For<ILogger>());
 
@@ -141,7 +149,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels
                 _clientChannel.ReadInbound<ProtocolMessage>();
                 _clientCorrelationManager.ReceivedWithAnyArgs(1).TryMatchResponse(Arg.Any<ProtocolMessage>());
 
-                _clientKeySigner.VerifyCount.Should().Be(1);
+                _clientKeySigner.ReceivedWithAnyArgs(1).Verify(null, null, null);
 
                 _testScheduler.Start();
 

--- a/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/PeerValidationIntegrationTest.cs
+++ b/src/Catalyst.Core.Lib.Tests/IntegrationTests/P2P/PeerValidationIntegrationTest.cs
@@ -39,8 +39,6 @@ using Catalyst.Core.Lib.IO.EventLoop;
 using Catalyst.Core.Lib.P2P;
 using Catalyst.Core.Lib.P2P.IO.Transport.Channels;
 using Catalyst.Core.Lib.P2P.Protocols;
-using Catalyst.Core.Lib.Tests.Fakes;
-using Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels;
 using Catalyst.Core.Lib.Util;
 using Catalyst.Core.Modules.Cryptography.BulletProofs;
 using Catalyst.Core.Modules.Hashing;
@@ -98,7 +96,10 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.P2P
                 UdpClientHandlerWorkerThreads = 5
             };
 
-            var keySigner = FakeKeySigner.SignAndVerify(true);
+            var keySigner = Substitute.For<FakeKeySigner>();
+            keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<byte[]>(), default).ReturnsForAnyArgs(true);
+            var signature = Substitute.For<ISignature>();
+            keySigner.Sign(Arg.Any<byte[]>(), default).ReturnsForAnyArgs(signature);
 
             _peerService = new PeerService(new UdpServerEventLoopGroupFactory(eventLoopGroupFactoryConfiguration),
                 new PeerServerChannelFactory(ContainerProvider.Container.Resolve<IPeerMessageCorrelationManager>(),

--- a/src/Catalyst.Core.Lib.Tests/IntegrationTests/Rpc/IO/Transport/Channels/RpcClientChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/IntegrationTests/Rpc/IO/Transport/Channels/RpcClientChannelFactoryTests.cs
@@ -56,10 +56,10 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
         private readonly EmbeddedChannel _serverChannel;
         private readonly EmbeddedChannel _clientChannel;
         private readonly IRpcMessageCorrelationManager _clientCorrelationManager;
-        private readonly IKeySigner _clientKeySigner;
+        private readonly FakeKeySigner _clientKeySigner;
         private readonly IAuthenticationStrategy _authenticationStrategy;
         private readonly IPeerIdValidator _peerIdValidator;
-        private readonly IKeySigner _serverKeySigner;
+        private readonly FakeKeySigner _serverKeySigner;
         private readonly IRpcMessageCorrelationManager _serverCorrelationManager;
 
         public RpcClientChannelFactoryTests()

--- a/src/Catalyst.Core.Lib.Tests/IntegrationTests/Rpc/IO/Transport/Channels/RpcClientChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/IntegrationTests/Rpc/IO/Transport/Channels/RpcClientChannelFactoryTests.cs
@@ -23,6 +23,8 @@
 
 using System.Linq;
 using System.Threading.Tasks;
+using Catalyst.Abstractions.Cryptography;
+using Catalyst.Abstractions.KeySigner;
 using Catalyst.Abstractions.P2P;
 using Catalyst.Abstractions.Rpc.Authentication;
 using Catalyst.Abstractions.Rpc.IO.Messaging.Correlation;
@@ -30,8 +32,6 @@ using Catalyst.Core.Lib.Extensions;
 using Catalyst.Core.Lib.IO.Handlers;
 using Catalyst.Core.Lib.IO.Messaging.Correlation;
 using Catalyst.Core.Lib.IO.Messaging.Dto;
-using Catalyst.Core.Lib.Tests.Fakes;
-using Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels;
 using Catalyst.Core.Lib.Util;
 using Catalyst.Core.Modules.Cryptography.BulletProofs;
 using Catalyst.Protocol.Network;
@@ -56,17 +56,17 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
         private readonly EmbeddedChannel _serverChannel;
         private readonly EmbeddedChannel _clientChannel;
         private readonly IRpcMessageCorrelationManager _clientCorrelationManager;
-        private readonly FakeKeySigner _clientKeySigner;
+        private readonly IKeySigner _clientKeySigner;
         private readonly IAuthenticationStrategy _authenticationStrategy;
         private readonly IPeerIdValidator _peerIdValidator;
-        private readonly FakeKeySigner _serverKeySigner;
+        private readonly IKeySigner _serverKeySigner;
         private readonly IRpcMessageCorrelationManager _serverCorrelationManager;
 
         public RpcClientChannelFactoryTests()
         {
             _testScheduler = new TestScheduler();
             _serverCorrelationManager = Substitute.For<IRpcMessageCorrelationManager>();
-            _serverKeySigner = FakeKeySigner.VerifyOnly();
+            _serverKeySigner = Substitute.For<FakeKeySigner>();
             _serverKeySigner.CryptoContext.SignatureLength.Returns(64);
 
             _authenticationStrategy = Substitute.For<IAuthenticationStrategy>();
@@ -84,7 +84,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
                 _testScheduler);
 
             _clientCorrelationManager = Substitute.For<IRpcMessageCorrelationManager>();
-            _clientKeySigner = FakeKeySigner.SignOnly();
+            _clientKeySigner = Substitute.For<FakeKeySigner>();
             _clientKeySigner.CryptoContext.SignatureLength.Returns(64);
             var clientFactory =
                 new UnitTests.Rpc.IO.Transport.Channels.RpcClientChannelFactoryTests.TestRpcClientChannelFactory(
@@ -108,9 +108,12 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
         {
             var recipient = PeerIdHelper.GetPeerId("recipient");
             var sender = PeerIdHelper.GetPeerId("sender");
-            _clientKeySigner.Signature.SignatureBytes.Returns(ByteUtil.GenerateRandomByteArray(new FfiWrapper().SignatureLength));
+            var signature = Substitute.For<ISignature>();
+            signature.SignatureBytes.Returns(ByteUtil.GenerateRandomByteArray(new FfiWrapper().SignatureLength));
 
             _peerIdValidator.ValidatePeerIdFormat(Arg.Any<PeerId>()).Returns(true);
+
+            _clientKeySigner.Sign(Arg.Any<byte[]>(), default).ReturnsForAnyArgs(signature);
 
             var correlationId = CorrelationId.GenerateCorrelationId();
 
@@ -131,7 +134,14 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
                 Arg.Is<CorrelatableMessage<ProtocolMessage>>(c =>
                     c.Content.CorrelationId.ToCorrelationId().Equals(correlationId)));
 
-            _clientKeySigner.SignCount.Should().Be(1);
+            _clientKeySigner.ReceivedWithAnyArgs(1).Sign(Arg.Is(signature.SignatureBytes), default);
+
+            _serverKeySigner.Verify(
+                    Arg.Any<ISignature>(),
+                    Arg.Any<byte[]>(),
+                    default
+                )
+               .ReturnsForAnyArgs(true);
 
             _authenticationStrategy.Authenticate(Arg.Any<PeerId>()).Returns(true);
 
@@ -145,7 +155,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
                 _serverChannel.WriteInbound(sentBytes);
                 _serverCorrelationManager.DidNotReceiveWithAnyArgs().TryMatchResponse(protocolMessage);
 
-                _serverKeySigner.VerifyCount.Should().Be(1);
+                _serverKeySigner.ReceivedWithAnyArgs(1).Verify(null, null, null);
 
                 _testScheduler.Start();
 

--- a/src/Catalyst.Core.Lib.Tests/IntegrationTests/Rpc/IO/Transport/Channels/RpcServerChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/IntegrationTests/Rpc/IO/Transport/Channels/RpcServerChannelFactoryTests.cs
@@ -54,10 +54,10 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
         private readonly EmbeddedChannel _serverChannel;
         private readonly EmbeddedChannel _clientChannel;
         private readonly IRpcMessageCorrelationManager _clientCorrelationManager;
-        private readonly IKeySigner _clientKeySigner;
+        private readonly FakeKeySigner _clientKeySigner;
         private readonly IAuthenticationStrategy _authenticationStrategy;
         private readonly IPeerIdValidator _peerIdValidator;
-        private readonly IKeySigner _serverKeySigner;
+        private readonly FakeKeySigner _serverKeySigner;
         private readonly IRpcMessageCorrelationManager _serverCorrelationManager;
 
         public RpcServerChannelFactoryTests()

--- a/src/Catalyst.Core.Lib.Tests/IntegrationTests/Rpc/IO/Transport/Channels/RpcServerChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/IntegrationTests/Rpc/IO/Transport/Channels/RpcServerChannelFactoryTests.cs
@@ -32,8 +32,6 @@ using Catalyst.Core.Lib.Extensions;
 using Catalyst.Core.Lib.IO.Handlers;
 using Catalyst.Core.Lib.IO.Messaging.Correlation;
 using Catalyst.Core.Lib.IO.Messaging.Dto;
-using Catalyst.Core.Lib.Tests.Fakes;
-using Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels;
 using Catalyst.Protocol.Network;
 using Catalyst.Protocol.Peer;
 using Catalyst.Protocol.Wire;
@@ -42,7 +40,6 @@ using Catalyst.TestUtils;
 using DotNetty.Buffers;
 using DotNetty.Transport.Channels.Embedded;
 using FluentAssertions;
-using Google.Protobuf;
 using Microsoft.Reactive.Testing;
 using NSubstitute;
 using Serilog;
@@ -57,17 +54,17 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
         private readonly EmbeddedChannel _serverChannel;
         private readonly EmbeddedChannel _clientChannel;
         private readonly IRpcMessageCorrelationManager _clientCorrelationManager;
-        private readonly FakeKeySigner _clientKeySigner;
+        private readonly IKeySigner _clientKeySigner;
         private readonly IAuthenticationStrategy _authenticationStrategy;
         private readonly IPeerIdValidator _peerIdValidator;
-        private readonly FakeKeySigner _serverKeySigner;
+        private readonly IKeySigner _serverKeySigner;
         private readonly IRpcMessageCorrelationManager _serverCorrelationManager;
 
         public RpcServerChannelFactoryTests()
         {
             _testScheduler = new TestScheduler();
             _serverCorrelationManager = Substitute.For<IRpcMessageCorrelationManager>();
-            _serverKeySigner = FakeKeySigner.SignOnly();
+            _serverKeySigner = Substitute.For<FakeKeySigner>();
             _serverKeySigner.CryptoContext.SignatureLength.Returns(64);
 
             _authenticationStrategy = Substitute.For<IAuthenticationStrategy>();
@@ -85,7 +82,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
                 _testScheduler);
 
             _clientCorrelationManager = Substitute.For<IRpcMessageCorrelationManager>();
-            _clientKeySigner = FakeKeySigner.VerifyOnly();
+            _clientKeySigner = Substitute.For<FakeKeySigner>();
             _clientKeySigner.CryptoContext.SignatureLength.Returns(64);
 
             _clientFactory = new UnitTests.Rpc.IO.Transport.Channels.RpcClientChannelFactoryTests.TestRpcClientChannelFactory(
@@ -109,7 +106,10 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
         {
             var recipient = PeerIdHelper.GetPeerId("recipient");
             var sender = PeerIdHelper.GetPeerId("sender");
+            var signature = Substitute.For<ISignature>();
             _peerIdValidator.ValidatePeerIdFormat(Arg.Any<PeerId>()).Returns(true);
+            
+            _serverKeySigner.Sign(Arg.Any<byte[]>(), default).ReturnsForAnyArgs(signature);
             
             var correlationId = CorrelationId.GenerateCorrelationId();
 
@@ -126,7 +126,14 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
 
             _serverCorrelationManager.DidNotReceiveWithAnyArgs().AddPendingRequest(Arg.Any<CorrelatableMessage<ProtocolMessage>>());
             
-            _serverKeySigner.SignCount.Should().Be(1);
+            _serverKeySigner.ReceivedWithAnyArgs(1)
+               .Sign(Arg.Any<byte[]>(), default);
+            
+            _clientKeySigner.Verify(
+                    Arg.Any<ISignature>(),
+                    Arg.Any<byte[]>(), 
+                    default)
+               .ReturnsForAnyArgs(true);
             
             _authenticationStrategy.Authenticate(Arg.Any<PeerId>()).Returns(true);
             
@@ -140,7 +147,7 @@ namespace Catalyst.Core.Lib.Tests.IntegrationTests.Rpc.IO.Transport.Channels
                 _clientChannel.ReadInbound<ProtocolMessage>();
                 _clientCorrelationManager.ReceivedWithAnyArgs(1).TryMatchResponse(Arg.Any<ProtocolMessage>());
                 
-                _clientKeySigner.VerifyCount.Should().Be(1);
+                _clientKeySigner.ReceivedWithAnyArgs(1).Verify(null, null, null);
 
                 _testScheduler.Start();
 

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/IO/Handlers/ProtocolMessageSignHandlerTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/IO/Handlers/ProtocolMessageSignHandlerTests.cs
@@ -43,7 +43,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.IO.Handlers
     {
         private readonly IChannelHandlerContext _fakeContext;
         private readonly IMessageDto<ProtocolMessage> _dto;
-        private readonly IKeySigner _keySigner;
+        private readonly FakeKeySigner _keySigner;
         private readonly ISignature _signature;
 
         public ProtocolMessageSignHandlerTests()

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/IO/Handlers/ProtocolMessageVerifyHandlerTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/IO/Handlers/ProtocolMessageVerifyHandlerTests.cs
@@ -41,7 +41,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.IO.Handlers
     {
         private readonly IChannelHandlerContext _fakeContext;
         private readonly ProtocolMessage _protocolMessageSigned;
-        private readonly IKeySigner _keySigner;
+        private readonly FakeKeySigner _keySigner;
         private readonly SigningContext _signingContext;
 
         public ProtocolMessageVerifyHandlerTests()

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/IO/Handlers/ProtocolMessageVerifyHandlerTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/IO/Handlers/ProtocolMessageVerifyHandlerTests.cs
@@ -24,8 +24,6 @@
 using Catalyst.Abstractions.Cryptography;
 using Catalyst.Abstractions.KeySigner;
 using Catalyst.Core.Lib.IO.Handlers;
-using Catalyst.Core.Lib.Tests.Fakes;
-using Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels;
 using Catalyst.Core.Lib.Util;
 using Catalyst.Core.Modules.Cryptography.BulletProofs;
 using Catalyst.Protocol.Cryptography;
@@ -34,7 +32,6 @@ using Catalyst.Protocol.Wire;
 using Catalyst.TestUtils;
 using Catalyst.TestUtils.Protocol;
 using DotNetty.Transport.Channels;
-using Google.Protobuf;
 using NSubstitute;
 using Xunit;
 
@@ -44,11 +41,13 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.IO.Handlers
     {
         private readonly IChannelHandlerContext _fakeContext;
         private readonly ProtocolMessage _protocolMessageSigned;
+        private readonly IKeySigner _keySigner;
         private readonly SigningContext _signingContext;
 
         public ProtocolMessageVerifyHandlerTests()
         {
             _fakeContext = Substitute.For<IChannelHandlerContext>();
+            _keySigner = Substitute.For<FakeKeySigner>();
             _signingContext = DevNetPeerSigningContext.Instance;
 
             var signatureBytes = ByteUtil.GenerateRandomByteArray(new FfiWrapper().SignatureLength);
@@ -63,7 +62,10 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.IO.Handlers
         [Fact]
         private void CanFireNextPipelineOnValidSignature()
         {
-            var signatureHandler = new ProtocolMessageVerifyHandler(FakeKeySigner.VerifyOnly());
+            _keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<byte[]>(), default)
+               .ReturnsForAnyArgs(true);
+
+            var signatureHandler = new ProtocolMessageVerifyHandler(_keySigner);
 
             signatureHandler.ChannelRead(_fakeContext, _protocolMessageSigned);
 
@@ -73,7 +75,10 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.IO.Handlers
         [Fact]
         private void CanFireNextPipelineOnInvalidSignature()
         {
-            var signatureHandler = new ProtocolMessageVerifyHandler(FakeKeySigner.VerifyOnly(false));
+            _keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<byte[]>(), default)
+               .ReturnsForAnyArgs(false);
+
+            var signatureHandler = new ProtocolMessageVerifyHandler(_keySigner);
 
             signatureHandler.ChannelRead(_fakeContext, _protocolMessageSigned);
             

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Messaging/Broadcast/BroadcastHandlerTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Messaging/Broadcast/BroadcastHandlerTests.cs
@@ -26,8 +26,6 @@ using Catalyst.Abstractions.Cryptography;
 using Catalyst.Abstractions.KeySigner;
 using Catalyst.Abstractions.P2P.IO.Messaging.Broadcast;
 using Catalyst.Core.Lib.IO.Handlers;
-using Catalyst.Core.Lib.Tests.Fakes;
-using Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels;
 using Catalyst.Core.Lib.Util;
 using Catalyst.Core.Modules.Cryptography.BulletProofs;
 using Catalyst.Protocol.Cryptography;
@@ -35,7 +33,6 @@ using Catalyst.Protocol.Wire;
 using Catalyst.TestUtils;
 using Catalyst.TestUtils.Protocol;
 using DotNetty.Transport.Channels.Embedded;
-using Google.Protobuf;
 using Microsoft.Reactive.Testing;
 using NSubstitute;
 using NSubstitute.ReceivedExtensions;
@@ -48,13 +45,14 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Messaging.Broadcast
     {
         private readonly IBroadcastManager _fakeBroadcastManager;
         private readonly BroadcastHandler _broadcastHandler;
-        private readonly FakeKeySigner _keySigner;
+        private readonly IKeySigner _keySigner;
         private readonly ProtocolMessage _broadcastMessageSigned;
         private readonly SigningContext _signingContext;
 
         public BroadcastHandlerTests()
         {
-            _keySigner = FakeKeySigner.VerifyOnly();
+            _keySigner = Substitute.For<FakeKeySigner>();
+            _keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<byte[]>(), default).ReturnsForAnyArgs(true);
             _fakeBroadcastManager = Substitute.For<IBroadcastManager>();
             _broadcastHandler = new BroadcastHandler(_fakeBroadcastManager);
 

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Messaging/Broadcast/BroadcastHandlerTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Messaging/Broadcast/BroadcastHandlerTests.cs
@@ -45,7 +45,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Messaging.Broadcast
     {
         private readonly IBroadcastManager _fakeBroadcastManager;
         private readonly BroadcastHandler _broadcastHandler;
-        private readonly IKeySigner _keySigner;
+        private readonly FakeKeySigner _keySigner;
         private readonly ProtocolMessage _broadcastMessageSigned;
         private readonly SigningContext _signingContext;
 

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Messaging/Broadcast/BroadcastManagerTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Messaging/Broadcast/BroadcastManagerTests.cs
@@ -49,7 +49,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Messaging.Broadcast
     {
         private readonly IPeerRepository _peers;
         private readonly IMemoryCache _cache;
-        private readonly IKeySigner _keySigner;
+        private readonly FakeKeySigner _keySigner;
         private readonly PeerId _senderPeerId;
         private readonly IPeerSettings _peerSettings;
 

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Messaging/Broadcast/BroadcastManagerTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Messaging/Broadcast/BroadcastManagerTests.cs
@@ -34,8 +34,6 @@ using Catalyst.Core.Lib.IO.Messaging.Dto;
 using Catalyst.Core.Lib.P2P.IO.Messaging.Broadcast;
 using Catalyst.Core.Lib.P2P.Models;
 using Catalyst.Core.Lib.P2P.Repository;
-using Catalyst.Core.Lib.Tests.Fakes;
-using Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels;
 using Catalyst.Protocol.Peer;
 using Catalyst.TestUtils;
 using FluentAssertions;
@@ -51,14 +49,16 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Messaging.Broadcast
     {
         private readonly IPeerRepository _peers;
         private readonly IMemoryCache _cache;
-        private readonly FakeKeySigner _keySigner;
+        private readonly IKeySigner _keySigner;
         private readonly PeerId _senderPeerId;
         private readonly IPeerSettings _peerSettings;
 
         public BroadcastManagerTests()
         {
             _senderPeerId = PeerIdHelper.GetPeerId("sender");
-            _keySigner = FakeKeySigner.SignOnly();
+            _keySigner = Substitute.For<FakeKeySigner>();
+            var fakeSignature = Substitute.For<ISignature>();
+            _keySigner.Sign(Arg.Any<byte[]>(), default).ReturnsForAnyArgs(fakeSignature);
             _keySigner.CryptoContext.SignatureLength.Returns(64);
             _peers = new PeerRepository(new InMemoryRepository<Peer, string>());
             _cache = new MemoryCache(new MemoryCacheOptions());

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Transport/Channels/PeerClientChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Transport/Channels/PeerClientChannelFactoryTests.cs
@@ -81,7 +81,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Transport.Channels
             _testScheduler = new TestScheduler();
             _correlationManager = Substitute.For<IPeerMessageCorrelationManager>();
             _gossipManager = Substitute.For<IBroadcastManager>();
-            _keySigner = Substitute.For<IKeySigner>();
+            _keySigner = Substitute.For<FakeKeySigner>();
 
             var peerSettings = Substitute.For<IPeerSettings>();
             peerSettings.NetworkType.Returns(NetworkType.Devnet);
@@ -136,7 +136,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Transport.Channels
                 testingChannel.WriteInbound(signedMessage);
                 _correlationManager.DidNotReceiveWithAnyArgs().TryMatchResponse(protocolMessage);
                 await _gossipManager.DidNotReceiveWithAnyArgs().BroadcastAsync(null);
-                _keySigner.ReceivedWithAnyArgs(1).Verify(null, default(byte[]), null);
+                _keySigner.ReceivedWithAnyArgs(1).Verify(null, null, null);
 
                 _testScheduler.Start();
 

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Transport/Channels/PeerServerChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Transport/Channels/PeerServerChannelFactoryTests.cs
@@ -75,7 +75,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Transport.Channels
         private readonly TestScheduler _testScheduler;
         private readonly IPeerMessageCorrelationManager _correlationManager;
         private readonly IBroadcastManager _gossipManager;
-        private readonly IKeySigner _keySigner;
+        private readonly FakeKeySigner _keySigner;
         private readonly TestPeerServerChannelFactory _factory;
         private readonly PeerId _senderId;
         private readonly ICorrelationId _correlationId;

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Transport/Channels/PeerServerChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/P2P/IO/Transport/Channels/PeerServerChannelFactoryTests.cs
@@ -34,8 +34,6 @@ using Catalyst.Core.Lib.Extensions;
 using Catalyst.Core.Lib.IO.Handlers;
 using Catalyst.Core.Lib.IO.Messaging.Correlation;
 using Catalyst.Core.Lib.P2P.IO.Transport.Channels;
-using Catalyst.Core.Lib.Tests.Fakes;
-using Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels;
 using Catalyst.Core.Lib.Util;
 using Catalyst.Core.Modules.Cryptography.BulletProofs;
 using Catalyst.Protocol.Wire;
@@ -46,7 +44,6 @@ using Catalyst.TestUtils;
 using DotNetty.Transport.Channels;
 using DotNetty.Transport.Channels.Embedded;
 using FluentAssertions;
-using Google.Protobuf;
 using Microsoft.Reactive.Testing;
 using NSubstitute;
 using Serilog;
@@ -78,7 +75,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Transport.Channels
         private readonly TestScheduler _testScheduler;
         private readonly IPeerMessageCorrelationManager _correlationManager;
         private readonly IBroadcastManager _gossipManager;
-        private readonly FakeKeySigner _keySigner;
+        private readonly IKeySigner _keySigner;
         private readonly TestPeerServerChannelFactory _factory;
         private readonly PeerId _senderId;
         private readonly ICorrelationId _correlationId;
@@ -89,7 +86,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Transport.Channels
             _testScheduler = new TestScheduler();
             _correlationManager = Substitute.For<IPeerMessageCorrelationManager>();
             _gossipManager = Substitute.For<IBroadcastManager>();
-            _keySigner = FakeKeySigner.VerifyOnly();
+            _keySigner = Substitute.For<FakeKeySigner>();
 
             var peerSettings = Substitute.For<IPeerSettings>();
             peerSettings.NetworkType.Returns(NetworkType.Devnet);
@@ -106,6 +103,8 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Transport.Channels
             _senderId = PeerIdHelper.GetPeerId("sender");
             _correlationId = CorrelationId.GenerateCorrelationId();
             _signature = ByteUtil.GenerateRandomByteArray(new FfiWrapper().SignatureLength);
+            _keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<byte[]>(), default)
+               .ReturnsForAnyArgs(true);
         }
 
         [Fact]
@@ -142,7 +141,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.P2P.IO.Transport.Channels
                 _correlationManager.DidNotReceiveWithAnyArgs().TryMatchResponse(protocolMessage);
                 await _gossipManager.DidNotReceiveWithAnyArgs().BroadcastAsync(null);
 
-                _keySigner.VerifyCount.Should().Be(1);
+                _keySigner.ReceivedWithAnyArgs(1).Verify(null, null, null);
 
                 _testScheduler.Start();
 

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Observers/VerifyMessageRequestObserverTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Observers/VerifyMessageRequestObserverTests.cs
@@ -34,8 +34,6 @@ using NSubstitute;
 using Serilog;
 using System.Linq;
 using Catalyst.Core.Lib.IO.Messaging.Dto;
-using Catalyst.Core.Lib.Tests.Fakes;
-using Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels;
 using Catalyst.Protocol.Cryptography;
 using Catalyst.Protocol.Network;
 using Catalyst.Protocol.Peer;
@@ -45,7 +43,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Observers
 {
     public sealed class VerifyMessageRequestObserverTests
     {
-        private readonly FakeKeySigner _keySigner;
+        private readonly IKeySigner _keySigner;
         private readonly VerifyMessageRequestObserver _verifyMessageRequestObserver;
         private readonly IChannelHandlerContext _fakeContext;
         private readonly PeerId _testPeerId;
@@ -64,8 +62,8 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Observers
 
             var peerSettings = _testPeerId.ToSubstitutedPeerSettings();
 
-            _keySigner = FakeKeySigner.SignAndVerify();
-            _keySigner.CryptoContext = new FfiWrapper();
+            _keySigner = Substitute.For<FakeKeySigner>();
+            _keySigner.CryptoContext.Returns(new FfiWrapper());
 
             var logger = Substitute.For<ILogger>();
             _fakeContext = Substitute.For<IChannelHandlerContext>();
@@ -95,14 +93,14 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Observers
         [Fact]
         public void VerifyMessageRequestObserver_Can_Send_True_If_Valid_Signature()
         {
-            _keySigner.EnableVerification(true);
+            _keySigner.Verify(default, default, default).ReturnsForAnyArgs(true);
             AssertVerifyResponse(true);
         }
 
         [Fact]
         public void VerifyMessageRequestObserver_Can_Send_False_Response_If_Verify_Fails()
         {
-            _keySigner.EnableVerification(false);
+            _keySigner.Verify(default, default, default).ReturnsForAnyArgs(false);
             AssertVerifyResponse(false);
         }
 

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Transport/Channels/RpcClientChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Transport/Channels/RpcClientChannelFactoryTests.cs
@@ -31,8 +31,6 @@ using Catalyst.Core.Lib.Extensions;
 using Catalyst.Core.Lib.IO.Codecs;
 using Catalyst.Core.Lib.IO.Handlers;
 using Catalyst.Core.Lib.IO.Messaging.Correlation;
-using Catalyst.Core.Lib.Tests.Fakes;
-using Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels;
 using Catalyst.Core.Lib.Util;
 using Catalyst.Core.Modules.Cryptography.BulletProofs;
 using Catalyst.Core.Modules.Rpc.Client.IO.Transport.Channels;
@@ -46,7 +44,6 @@ using DotNetty.Codecs.Protobuf;
 using DotNetty.Transport.Channels;
 using DotNetty.Transport.Channels.Embedded;
 using FluentAssertions;
-using Google.Protobuf;
 using Microsoft.Reactive.Testing;
 using NSubstitute;
 using Serilog;
@@ -76,13 +73,13 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Transport.Channels
         private readonly TestScheduler _testScheduler;
         private readonly IRpcMessageCorrelationManager _correlationManager;
         private readonly TestRpcClientChannelFactory _factory;
-        private readonly FakeKeySigner _keySigner;
+        private readonly IKeySigner _keySigner;
 
         public RpcClientChannelFactoryTests()
         {
             _testScheduler = new TestScheduler();
             _correlationManager = Substitute.For<IRpcMessageCorrelationManager>();
-            _keySigner = FakeKeySigner.VerifyOnly();
+            _keySigner = Substitute.For<FakeKeySigner>();
 
             var peerIdValidator = Substitute.For<IPeerIdValidator>();
             peerIdValidator.ValidatePeerIdFormat(Arg.Any<PeerId>()).Returns(true);
@@ -124,6 +121,9 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Transport.Channels
             var protocolMessage = new PingResponse()
                .ToSignedProtocolMessage(senderId, signatureBytes, correlationId: correlationId);
 
+            _keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<byte[]>(), Arg.Any<SigningContext>())
+               .Returns(true);
+
             _correlationManager.TryMatchResponse(protocolMessage).Returns(true);
 
             var observer = new ProtocolMessageObserver(0, Substitute.For<ILogger>());
@@ -136,7 +136,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Transport.Channels
 
                 _correlationManager.Received(1).TryMatchResponse(protocolMessage);
 
-                _keySigner.VerifyCount.Should().Be(1);
+                _keySigner.ReceivedWithAnyArgs(1).Verify(null, null, null);
 
                 _testScheduler.Start();
 
@@ -159,6 +159,8 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Transport.Channels
 
             _correlationManager.DidNotReceiveWithAnyArgs().TryMatchResponse(default);
             
+            _keySigner.DidNotReceiveWithAnyArgs().Sign(Arg.Any<byte[]>(), default);
+
             testingChannel.ReadOutbound<IByteBuffer>();
         }
     }

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Transport/Channels/RpcClientChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Transport/Channels/RpcClientChannelFactoryTests.cs
@@ -73,7 +73,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Transport.Channels
         private readonly TestScheduler _testScheduler;
         private readonly IRpcMessageCorrelationManager _correlationManager;
         private readonly TestRpcClientChannelFactory _factory;
-        private readonly IKeySigner _keySigner;
+        private readonly FakeKeySigner _keySigner;
 
         public RpcClientChannelFactoryTests()
         {

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Transport/Channels/RpcServerChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Transport/Channels/RpcServerChannelFactoryTests.cs
@@ -75,7 +75,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Transport.Channels
         private readonly TestScheduler _testScheduler;
         private readonly IRpcMessageCorrelationManager _correlationManager;
         private readonly TestRpcServerChannelFactory _factory;
-        private readonly IKeySigner _keySigner;
+        private readonly FakeKeySigner _keySigner;
 
         public RpcServerChannelFactoryTests()
         {

--- a/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Transport/Channels/RpcServerChannelFactoryTests.cs
+++ b/src/Catalyst.Core.Lib.Tests/UnitTests/Rpc/IO/Transport/Channels/RpcServerChannelFactoryTests.cs
@@ -32,8 +32,6 @@ using Catalyst.Core.Lib.Extensions;
 using Catalyst.Core.Lib.IO.Codecs;
 using Catalyst.Core.Lib.IO.Handlers;
 using Catalyst.Core.Lib.IO.Messaging.Correlation;
-using Catalyst.Core.Lib.Tests.Fakes;
-using Catalyst.Core.Lib.Tests.IntegrationTests.P2P.IO.Transport.Channels;
 using Catalyst.Core.Lib.Util;
 using Catalyst.Core.Modules.Cryptography.BulletProofs;
 using Catalyst.Core.Modules.Rpc.Server.Transport.Channels;
@@ -47,7 +45,6 @@ using DotNetty.Codecs.Protobuf;
 using DotNetty.Transport.Channels;
 using DotNetty.Transport.Channels.Embedded;
 using FluentAssertions;
-using Google.Protobuf;
 using Microsoft.Reactive.Testing;
 using NSubstitute;
 using Serilog;
@@ -78,13 +75,13 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Transport.Channels
         private readonly TestScheduler _testScheduler;
         private readonly IRpcMessageCorrelationManager _correlationManager;
         private readonly TestRpcServerChannelFactory _factory;
-        private readonly FakeKeySigner _keySigner;
+        private readonly IKeySigner _keySigner;
 
         public RpcServerChannelFactoryTests()
         {
             _testScheduler = new TestScheduler();
             _correlationManager = Substitute.For<IRpcMessageCorrelationManager>();
-            _keySigner = FakeKeySigner.VerifyOnly();
+            _keySigner = Substitute.For<FakeKeySigner>();
             _keySigner.CryptoContext.SignatureLength.Returns(64);
 
             var authenticationStrategy = Substitute.For<IAuthenticationStrategy>();
@@ -130,7 +127,8 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Transport.Channels
             var senderId = PeerIdHelper.GetPeerId("sender");
             var correlationId = CorrelationId.GenerateCorrelationId();
             var signatureBytes = ByteUtil.GenerateRandomByteArray(new FfiWrapper().SignatureLength);
-        
+            _keySigner.Verify(Arg.Any<ISignature>(), Arg.Any<byte[]>(), Arg.Any<SigningContext>())
+               .Returns(true);
             var protocolMessage = new PingRequest().ToSignedProtocolMessage(senderId, signatureBytes, correlationId: correlationId);
 
             var observer = new ProtocolMessageObserver(0, Substitute.For<ILogger>());
@@ -142,7 +140,7 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Transport.Channels
             {
                 testingChannel.WriteInbound(protocolMessage);
                 _correlationManager.DidNotReceiveWithAnyArgs().TryMatchResponse(protocolMessage);
-                _keySigner.VerifyCount.Should().Be(1);
+                _keySigner.ReceivedWithAnyArgs(1).Verify(null, null, null);
                 _testScheduler.Start();
                 observer.Received.Count.Should().Be(1);
                 observer.Received.Single().Payload.CorrelationId.ToCorrelationId().Id.Should().Be(correlationId.Id);
@@ -163,6 +161,8 @@ namespace Catalyst.Core.Lib.Tests.UnitTests.Rpc.IO.Transport.Channels
 
             _correlationManager.DidNotReceiveWithAnyArgs().TryMatchResponse(protocolMessage);
             
+            _keySigner.DidNotReceiveWithAnyArgs().Sign(Arg.Any<byte[]>(), default);
+
             testingChannel.ReadOutbound<IByteBuffer>();
         }
     }


### PR DESCRIPTION
### New Pull Request Submissions:

1. [x] Have you followed the guidelines in our [Contributing document](https://github.com/atlascity/Community/tree/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
3. [ ] I have added tests to cover my changes.
4. [x] All new and existing tests passed.
5. [ ] Have you lint your code locally prior to submission?
6. [ ] Does your code follows the code style of this project?
7. [ ] Does your change require a change to the documentation.
    - [ ] I have updated the documentation accordingly.
9. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
10. [ ] Have you inserted a keyword and link to the issues the PR closes in its descriptions (ex `closes #1`) ?
11. [x] Is you branch up to date, have you integrated all the latest changes from develop and resolved conflicts ?

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR changes the way `IKeySigner` and others Span-based interfaces can be substituted. Previously, they requires a custom class with logic and prohibited usage of NSubstitute. With the new approach, one class needs to be written with one method per Span-based method added

```csharp
public abstract class FakeKeySigner : IKeySigner
{
    // span-based that cannot be substituted because of the by-ref semantics of span
    ISignature IKeySigner.Sign(ReadOnlySpan<byte> data, SigningContext signingContext)
    {
        // just delegate to the byte[] method
        return Sign(data.ToArray(), signingContext);
    }
    // method that can be substituted
    public abstract ISignature Sign(byte[] data, SigningContext signingContext);
}
```

* **What is the current behavior?** (You can also link to an open issue here)

Currently, custom classes with logic needed to be created, changing the way substitutes were created.

* **What is the new behavior (if this is a feature change)?**

It introduces a more coherent testing approach.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

It does not. It just makes the testing more convenient and coherent

* **Other information**:
